### PR TITLE
Migrate spectator_client module from spinnaker/google/stackdriver_mon…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Distribution / packaging
+env/
+build/
+dist/
+eggs/
+.eggs/
+parts/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+*.pyc
+*~

--- a/conf.dev/sources/clouddriver.conf
+++ b/conf.dev/sources/clouddriver.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:7002/spectator/metrics

--- a/conf.dev/sources/echo.conf
+++ b/conf.dev/sources/echo.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:8089/spectator/metrics

--- a/conf.dev/sources/fiat.conf
+++ b/conf.dev/sources/fiat.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:7003/spectator/metrics

--- a/conf.dev/sources/front50.conf
+++ b/conf.dev/sources/front50.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:8080/spectator/metrics

--- a/conf.dev/sources/gate.conf
+++ b/conf.dev/sources/gate.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:8084/spectator/metrics

--- a/conf.dev/sources/igor.conf
+++ b/conf.dev/sources/igor.conf
@@ -1,0 +1,5 @@
+metrics_url: http://localhost:8088/spectator/metrics
+
+
+
+

--- a/conf.dev/sources/orca.conf
+++ b/conf.dev/sources/orca.conf
@@ -1,0 +1,5 @@
+metrics_url: http://localhost:8083/spectator/metrics
+
+
+
+

--- a/conf.dev/sources/rosco.conf
+++ b/conf.dev/sources/rosco.conf
@@ -1,0 +1,1 @@
+metrics_url: http://localhost:8087/spectator/metrics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# sudo apt-get install python-dev
+--index-url https://pypi.python.org/simple/
+
+pyyaml
+mock

--- a/spinnaker-monitoring/spectator_client.py
+++ b/spinnaker-monitoring/spectator_client.py
@@ -1,0 +1,392 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+# pylint: disable=star-args
+# pylint: disable=global-statement
+
+import base64
+import copy
+import glob
+import json
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+import traceback
+import urllib2
+import urlparse
+import yaml
+
+
+CONFIG_DIR = '/opt/monitor_spinnaker/config'
+
+# pylint: disable=invalid-name
+_cached_source_catalog = None
+_cached_source_timestamp = None
+
+
+def get_source_catalog(config_dir=None):
+  """Returns a dictionary of source name to source configuration document.
+
+  Args:
+    config_dir: [string] The base config directory to load from.
+        The source configurations are expected to be in a 'sources' subdir.
+
+  Returns:
+    Dictionary keyed by the root name of the config file in <config_dir>
+       whose value is the dictionary of the YAML file content.
+  """
+  config_dir = config_dir or CONFIG_DIR
+  source_dir = os.path.join(config_dir, 'sources')
+
+  global _cached_source_catalog
+  global _cached_source_timestamp
+  try:
+    timestamp = os.path.getmtime(source_dir)
+  except OSError as err:
+    logging.error(err)
+    return _cached_source_catalog or {}
+
+  if _cached_source_timestamp == timestamp:
+    return _cached_source_catalog
+
+  logging.info('Updating catalog from %s at %ld', source_dir, timestamp)
+  catalog = {}
+  for source in glob.glob(os.path.join(source_dir, '*.conf')):
+    name = os.path.splitext(os.path.basename(source))[0]
+    logging.info('loading %s', source)
+    with open(source) as stream:
+      doc = yaml.safe_load(stream)
+      url = doc.get('metrics_url')
+      if url is None:
+        logging.error('%s is missing "metrics_url"', source)
+        continue
+      doc['metrics_url'] = url if isinstance(url, list) else [url]
+      catalog[name] = doc
+
+  _cached_source_catalog = catalog
+  _cached_source_timestamp = timestamp
+  return catalog
+
+
+def __foreach_metric_tag_binding(
+    service, metric_name, metric_data, service_data,
+    visitor, visitor_pos_args, visitor_kwargs):
+  for metric_instance in metric_data['values']:
+    visitor(service, metric_name, metric_instance, metric_data, service_data,
+            *visitor_pos_args, **visitor_kwargs)
+
+
+def foreach_metric_in_service_map(
+    service_map, visitor, *visitor_pos_args, **visitor_kwargs):
+  for service, service_metric_list in service_map.items():
+    if not service_metric_list:
+      continue
+    for service_metrics in service_metric_list:
+      for metric_name, metric_data in service_metrics['metrics'].items():
+        __foreach_metric_tag_binding(
+            service, metric_name, metric_data, service_metrics,
+            visitor, visitor_pos_args, visitor_kwargs)
+
+
+def normalize_name_and_tags(name, metric_instance, metric_metadata):
+  tags = metric_instance.get('tags', None)
+  if not tags:
+    return name, None   # signal this metric had no tags so we can ignore it.
+
+  is_timer = metric_metadata['kind'] == 'Timer'
+  if is_timer:
+    tags = list(tags)
+    for index, tag in enumerate(tags):
+      if tag['key'] == 'statistic':
+        name = name + '__{0}'.format(tag['value'])
+        del tags[index]
+        break
+  return name, tags
+
+
+class SpectatorClient(object):
+  """Helper class for pulling data from Spectator servers."""
+
+  @staticmethod
+  def add_standard_parser_arguments(parser):
+    parser.add_argument('--prototype_path', default='',
+                        help='Optional filter to restrict metrics of interest.')
+    parser.add_argument(
+        '--log_metric_diff',
+        default=False, action='store_true',
+        help='Keep track of the last set of metrics/bindings were'
+             ' and show the differences with the current metric/bindings.'
+             ' This is to show a change in what metrics are available, not'
+             ' the values of the metrics themselves.')
+
+
+  def __init__(self, options):
+    self.__prototype = None
+    self.__default_scan_params = {'tagNameRegex': '.+'}
+    self.__previous_scan_lock = threading.Lock()
+    self.__previous_scan = {} if options.get('log_metric_diff') else None
+
+    if options['prototype_path']:
+      # pylint: disable=invalid-name
+      with open(options['prototype_path']) as fd:
+        self.__prototype = json.JSONDecoder().decode(fd.read())
+
+  def __log_scan_diff(self, host, port, metrics):
+    """Diff this scan with the previous one for debugging purposes."""
+    if self.__previous_scan is None:
+      return
+
+    key = '{0}:{1}'.format(host, port)
+    with self.__previous_scan_lock:
+      previous_metrics = self.__previous_scan.get(key, {})
+      self.__previous_scan[key] = copy.deepcopy(metrics)
+    if not previous_metrics:
+      return
+
+    previous_keys = set(previous_metrics.keys())
+    keys = set(metrics.keys())
+    new_keys = keys.difference(previous_keys)
+    same_keys = keys.intersection(previous_keys)
+    lost_keys = previous_keys.difference(keys)
+    lines = []
+
+    if lost_keys:
+      lines.append('Stopped metrics for:\n  - {0}\n'
+                   .format('\n  - '.join(lost_keys)))
+    if new_keys:
+      lines.append('Started metrics for:\n  - {0}\n'
+                   .format('\n  - '.join(new_keys)))
+
+    def normalize_tags(tag_list):
+      result = set([])
+      for item in sorted(tag_list):
+        result.add('{0}={1}'.format(item['key'], item['value']))
+
+      return ', '.join(result)
+
+    for check_key in same_keys:
+      tag_sets = set(
+          [normalize_tags(item.get('tags', []))
+           for item in metrics[check_key].get('values', [])])
+      prev_tag_sets = set(
+          [normalize_tags(item.get('tags', []))
+           for item in previous_metrics[check_key].get('values', [])])
+      added_tags = tag_sets.difference(prev_tag_sets)
+      lost_tags = prev_tag_sets.difference(tag_sets)
+
+      if added_tags:
+        lines.append('"{0}" started data points for\n  - {1}\n'
+                     .format(check_key, '\n  - '.join(added_tags)))
+      if lost_tags:
+        lines.append('"{0}" stopped data points for\n  - {1}\n'
+                     .format(check_key, '\n  - '.join(lost_tags)))
+    if lines:
+      logging.info('==== DIFF %s ===\n%s\n', key, '\n'.join(lines))
+
+  def create_request(self, url, authorization):
+    """Helper function to create a request to facilitate testing.
+
+    Wrapper around creating a Request because Request does not implement
+    equals so it's difficult to test directly.
+
+    Args:
+      url: [string] The url for the request.
+      authorization: [string] None or the base64 encoded authorization string.
+
+    Returns:
+      urllib2.Request instance
+    """
+    request = urllib2.Request(url)
+    if authorization:
+      request.add_header('Authorization', 'Basic %s' % authorization)
+    return request
+
+  def collect_metrics(self, base_url, params=None):
+    """Return JSON metrics from the given server."""
+    info = urlparse.urlsplit(base_url)
+    host = info.hostname
+    port = info.port or 80
+    netloc = host
+
+    if info.port:
+      netloc += ':{0}'.format(info.port)
+    base_url = '{scheme}://{netloc}{path}'.format(
+        scheme=info.scheme, netloc=netloc, path=info.path)
+
+    authorization = None
+    if info.username or info.password:
+      authorization = base64.encodestring(
+          '%s:%s' % (info.username, info.password)).replace('\n', '')
+
+    query = '?' + info.query if info.query else ''
+    sep = '&' if info.query else '?'
+    query_params = dict(self.__default_scan_params)
+    if params is None:
+      params = {}
+    keys_to_copy = [key
+                    for key in ['tagNameRegex', 'tagValueRegex',
+                                'meterNameRegex']
+                    if key in params]
+    for key in keys_to_copy:
+      query_params[key] = params[key]
+
+    for key, value in query_params.items():
+      query += sep + key + "=" + urllib2.quote(value)
+      sep = "&"
+
+    url = '{base_url}{query}'.format(base_url=base_url, query=query)
+    response = urllib2.urlopen(self.create_request(url, authorization))
+
+    all_metrics = json.JSONDecoder(encoding='utf-8').decode(response.read())
+    try:
+      self.__log_scan_diff(host, port + 1012, all_metrics.get('metrics', {}))
+    except:
+      extype, exvalue, ignore_tb = sys.exc_info()
+      logging.error(traceback.format_exception_only(extype, exvalue))
+
+    # Record how many data values we collected.
+    # Add success tag so we have a tag and dont get filtered out.
+    num_metrics = 0
+    for metric_data in all_metrics.get('metrics', {}).values():
+      num_metrics += len(metric_data.get('values', []))
+
+    all_metrics['__port'] = port
+    all_metrics['__host'] = (socket.getfqdn()
+                             if host in ['localhost', '127.0.0.1', None, '']
+                             else host)
+    all_metrics['metrics']['spectator.datapoints'] = {
+        'kind': 'Gauge',
+        'values': [{
+            'tags': [{'key': 'success', 'value': "true"}],
+            'values': [{'v': num_metrics, 't': int(time.time() * 1000)}]
+        }]
+    }
+
+    return (self.filter_metrics(all_metrics, self.__prototype)
+            if self.__prototype else all_metrics)
+
+  def filter_metrics(self, instance, prototype):
+    """Filter metrics entries in |instance| to those that match |prototype|.
+
+    Only the names and tags are checked. The instance must contain a
+    tag binding found in the prototype, but may also contain additional tags.
+    The prototype is the same format as the json of the metrics returned.
+    """
+    filtered = {}
+
+    metrics = instance.get('metrics') or {}
+    for key, expect in prototype.get('metrics', {}).items():
+      got = metrics.get(key)
+      if not got:
+        continue
+      expect_values = expect.get('values')
+      if not expect_values:
+        filtered[key] = got
+        continue
+
+      expect_tags = [elem.get('tags') for elem in expect_values]
+
+      # Clone the dict because we are going to modify it to remove values
+      # we dont care about
+      keep_values = []
+      def have_tags(expect_tags, got_tags):
+        for wanted_set in expect_tags:
+          # pylint: disable=invalid-name
+          ok = True
+          for want in wanted_set:
+            if want not in got_tags:
+              ok = False
+              break
+          if ok:
+            return True
+
+        return expect_tags == []
+
+      for got_value in got.get('values', []):
+        got_tags = got_value.get('tags')
+        if have_tags(expect_tags, got_tags):
+          keep_values.append(got_value)
+      if not keep_values:
+        continue
+
+      keep = dict(got)
+      keep['values'] = keep_values
+      filtered[key] = keep
+
+    result = dict(instance)
+    result['metrics'] = filtered
+    return result
+
+  def scan_by_service(self, service_catalog, params=None):
+    result = {}
+
+    start = time.time()
+    service_time = {service: 0 for service in service_catalog.keys()}
+    result = {service: None for service in service_catalog.keys()}
+    threads = {}
+
+    def timed_collect(self, service, url_endpoints):
+      now = time.time()
+      endpoint_data_list = []
+      for service_url in url_endpoints:
+        try:
+          endpoint_data_list.append(self.collect_metrics(
+              service_url, params=params))
+        except IOError as ioex:
+          logging.getLogger(__name__).error(
+              '%s failed %s with %s',
+              service, service_url, ioex)
+
+      result[service] = endpoint_data_list
+      service_time[service] = int((time.time() - now) * 1000)
+
+    for service, config in service_catalog.items():
+      threads[service] = threading.Thread(
+          target=timed_collect,
+          args=(self, service, config['metrics_url']))
+      threads[service].start()
+    for service in service_catalog.keys():
+      threads[service].join()
+
+    logging.info('Collection times %d (ms): %s',
+                 (time.time() - start) * 1000, service_time)
+    return result
+
+  def scan_by_type(self, service_catalog, params=None):
+    service_map = self.scan_by_service(service_catalog, params=params)
+    return self.service_map_to_type_map(service_map)
+
+  @staticmethod
+  def ingest_metrics(service, response_data, type_map):
+    """Add JSON |metric_data| from |service| name and add to |type_map|"""
+    metric_data = response_data.get('metrics', {})
+    for key, value in metric_data.items():
+      if key in type_map:
+        have = type_map[key].get(service, [])
+        have.append(value)
+        type_map[key][service] = have
+      else:
+        type_map[key] = {service: [value]}
+
+  @staticmethod
+  def service_map_to_type_map(service_map):
+    type_map = {}
+    for service, got_from_each_endpoint in service_map.items():
+      for got in got_from_each_endpoint or []:
+        SpectatorClient.ingest_metrics(service, got, type_map)
+    return type_map

--- a/spinnaker-monitoring/util.py
+++ b/spinnaker-monitoring/util.py
@@ -1,0 +1,46 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for reading configs from yaml files."""
+
+
+import logging
+import yaml
+
+
+def load_yaml_options(config_path):
+  """Load options from the YAML file at the specified path.
+
+  Returns an empty dictionary and logs a warning on error.
+  """
+  config = {}
+  try:
+    with open(config_path, 'r') as stream:
+      config = yaml.safe_load(stream)
+      logging.info('Loaded config from %s', config_path)
+  except IOError:
+    logging.warn('Failed to load %s', config_path)
+  return config
+
+
+def merge_options_and_yaml_from_path(options, config_path):
+  """Return a new dictionary containing all the options and YAML info.
+
+  Non-None option values have higher precedence if found in both places.
+  """
+  config = load_yaml_options(config_path)
+  for key, value in options.items():
+    if value is not None:
+      config[key] = value
+  return config

--- a/tests/spectator_client_test.py
+++ b/tests/spectator_client_test.py
@@ -1,0 +1,533 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import base64
+import copy
+import json
+import os
+import sys
+import unittest
+from StringIO import StringIO
+import mock
+from mock import patch
+from urllib2 import Request
+
+import spectator_client
+
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+
+
+def args_to_options(args):
+  parser = argparse.ArgumentParser()
+  spectator_client.SpectatorClient.add_standard_parser_arguments(parser)
+  old_argv = sys.argv
+  try:
+    sys.argv = ['foo']
+    sys.argv.extend(args)
+    options = vars(parser.parse_args())
+  finally:
+    sys.argv = old_argv
+  return options
+
+
+TEST_HOST = 'test_hostname'
+
+
+CLOUDDRIVER_RESPONSE_OBJ = {
+  'applicationName': 'clouddriver',
+  'metrics' : {
+    'jvm.buffer.memoryUsed' : {
+      'kind': 'AggrMeter',
+      'values': [{
+          'tags': [{'key': 'id', 'value': 'mapped'}],
+          'values': [{'t': 1471917869670, 'v': 0.0}]
+       }, {
+          'tags': [{'key': 'id', 'value': 'direct'}],
+          'values': [{'t': 1471917869671, 'v': 81920.0}]
+       }]
+    },
+    'jvm.gc.maxDataSize' : {
+      'kind': 'AggrMeter',
+      'values': [{
+        'tags': [],
+        'values': [{'t': 1471917869672, 'v': 12345.0}]
+      }]
+    },
+    'tasks': {
+      'kind': 'Counter',
+      'values': [{
+        'tags': [{'key': 'success', 'value': 'true'}],
+        'values': [{'t': 1471917869673, 'v': 24.0}]
+      }]
+    }
+  }
+}
+
+
+CLOUDDRIVER_RESPONSE_TEXT = json.JSONEncoder(encoding='utf-8').encode(
+    CLOUDDRIVER_RESPONSE_OBJ)
+
+
+GATE_RESPONSE_OBJ = {
+  'applicationName': 'gate',
+  'metrics' : {
+    'jvm.buffer.memoryUsed' : {
+      'kind': 'AggrMeter',
+      'values': [{
+          'tags': [{'key': 'id', 'value': 'mapped'}],
+          'values': [{'t': 1471917869677, 'v': 2.0}]
+        }, {
+          'tags': [{'key': 'id', 'value': 'direct'}],
+          'values': [{'t': 1471917869678, 'v': 22222.0}]
+        }]
+    },
+    'jvm.gc.maxDataSize': {
+      'kind': 'AggrMeter',
+      'values': [{
+        'tags': [],
+        'values': [{'t' : 1471917869679, 'v' : 54321.0}]
+      }]
+    },
+    'controller.invocations': {
+      'kind': 'Timer',
+      'values': [{
+        'tags': [{'key': 'controller', 'value': 'PipelineController'},
+                 {'key': 'method', 'value': 'savePipeline'}],
+        'values': [{'t' : 1471917869679, 'v' : 1.0}]
+      }]
+    }
+  }
+}
+
+GATE_RESPONSE_TEXT = json.JSONEncoder(encoding='utf-8').encode(
+    GATE_RESPONSE_OBJ)
+
+
+class TestableSpectatorClient(spectator_client.SpectatorClient):
+  def __init__(self, options):
+    self.requests = []
+    super(TestableSpectatorClient, self).__init__(options)
+
+  def create_request(self, url, authorization):
+    self.requests.append((url, authorization))
+    return super(TestableSpectatorClient, self).create_request(url, authorization)
+
+
+class SpectatorClientTest(unittest.TestCase):
+  DEV_CONF_DIR = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), '..', 'conf.dev'))
+
+  def setUp(self):
+    options = {'prototype_path': None, 'host': TEST_HOST}
+    self.spectator = TestableSpectatorClient(options)
+    self.default_query_params = '?tagNameRegex=.%2B'  # tagNameRegex=.+
+
+
+  @patch('glob.glob')
+  @patch('os.path.getmtime')
+  def test_get_source_catalog(self, mock_getmtime, mock_glob):
+    mock_getmtime.return_value = 1234
+    mock_glob.return_value = ['one.conf', 'two.conf']
+    mo = mock.mock_open(read_data='metrics_url: http://testhost:1122')
+    mo.side_effect = (
+        mo.return_value,
+        mock.mock_open(
+            read_data='metrics_url: http://testhost:3344').return_value)
+    with patch('spectator_client.open', mo, create=True):
+      catalog = spectator_client.get_source_catalog(config_dir='TestConfig')
+    self.assertEqual({'one': {'metrics_url': ['http://testhost:1122']},
+                      'two': {'metrics_url': ['http://testhost:3344']}},
+                     catalog)
+    mock_getmtime.assert_called_with('TestConfig/sources')
+    mock_glob.assert_called_with('TestConfig/sources/*.conf')
+    self.assertEquals(1, mock_getmtime.call_count)
+
+    # Verify that we dont rescan content if timestamp hasnt changed.
+    again = spectator_client.get_source_catalog('TestConfig')
+    self.assertEquals(catalog, again)
+    self.assertEquals(2, mock_getmtime.call_count)
+    self.assertEquals(1, mock_glob.call_count)
+
+    # Verify that we query again if timestamp changes
+    mock_getmtime.return_value = 1235
+    mock_glob.return_value = ['three.conf']
+    mo = mock.mock_open(read_data='metrics_url: http://testhost:3333')
+    with patch('spectator_client.open', mo, create=True):
+      retry = spectator_client.get_source_catalog('TestConfig')
+    self.assertEqual({'three': {'metrics_url': ['http://testhost:3333']}},
+                     retry)
+
+  def test_default_dev_endpoints(self):
+    got_urls = {name: config['metrics_url']
+                for name, config in spectator_client.get_source_catalog(
+                    config_dir=self.DEV_CONF_DIR).items()}
+
+    def localhost_urls(port):
+      return ['http://localhost:{port}/spectator/metrics'.format(port=port)]
+    self.assertEquals({'clouddriver': localhost_urls(7002),
+                       'echo': localhost_urls(8089),
+                       'fiat': localhost_urls(7003),
+                       'front50': localhost_urls(8080),
+                       'gate': localhost_urls(8084),
+                       'igor': localhost_urls(8088),
+                       'orca': localhost_urls(8083),
+                       'rosco': localhost_urls(8087)},
+                      got_urls)
+
+  @patch('spectator_client.time.time')
+  @patch('spectator_client.urllib2.urlopen')
+  def test_collect_metrics_no_params(self, mock_urlopen, mock_time):
+    now_time = 1.234
+    port = 80
+    url = 'http://{0}/spectator-metrics'.format(TEST_HOST)
+    metrics_response = CLOUDDRIVER_RESPONSE_OBJ
+    expect = copy.deepcopy(metrics_response)
+    expect['__host'] = TEST_HOST
+    expect['__port'] = port
+    expect['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]
+    }
+
+    text = json.JSONEncoder(encoding='utf-8').encode(metrics_response)
+    mock_http_response = StringIO(text)
+    mock_urlopen.return_value = mock_http_response
+    mock_time.return_value = now_time
+
+    response = self.spectator.collect_metrics(url)
+    self.assertEquals([(url + self.default_query_params, None)],
+                      self.spectator.requests)
+    self.assertEqual(expect, response)
+
+  @patch('spectator_client.urllib2.urlopen')
+  def test_collect_metrics_with_params(self, mock_urlopen):
+    port = 13246
+    url = 'http://{0}:{1}/spectator-metrics'.format(TEST_HOST, port)
+
+    params = {'tagNameRegex': 'someName', 'tagValueRegex': 'Second+Part&Third'}
+    encoded_params = {'tagNameRegex': 'someName',
+                      'tagValueRegex': 'Second%2BPart%26Third'}
+    expected_query = ''
+    for key in params.keys():
+      expected_query += '{sep}{key}={value}'.format(
+          sep='&' if expected_query else '?',
+          key=key,
+          value=encoded_params[key])
+
+    text = json.JSONEncoder(encoding='utf-8').encode(CLOUDDRIVER_RESPONSE_OBJ)
+    mock_http_response = StringIO(text)
+    mock_urlopen.return_value = mock_http_response
+
+    self.spectator.collect_metrics(url, params)
+    self.assertEquals([(url + expected_query, None)],
+                      self.spectator.requests)
+
+  @patch('spectator_client.time.time')
+  @patch('spectator_client.urllib2.urlopen')
+  def test_collect_metrics_with_password(self, mock_urlopen, mock_time):
+    now_time = 1.234
+    port = 80
+    url = 'https://TESTUSER:TESTPASSWORD@{0}/spectator-metrics'.format(TEST_HOST)
+    metrics_response = CLOUDDRIVER_RESPONSE_OBJ
+    expect = copy.deepcopy(metrics_response)
+    expect['__host'] = TEST_HOST
+    expect['__port'] = port
+    expect['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]
+    }
+
+    text = json.JSONEncoder(encoding='utf-8').encode(metrics_response)
+    mock_http_response = StringIO(text)
+    mock_urlopen.return_value = mock_http_response
+    mock_time.return_value = now_time
+
+    response = self.spectator.collect_metrics(url)
+    self.assertEquals([
+      ('https://{0}/spectator-metrics{1}'.format(TEST_HOST,
+                                                 self.default_query_params),
+           base64.encodestring('TESTUSER:TESTPASSWORD').replace('\n', ''))],
+       self.spectator.requests)
+    self.assertEqual(expect, response)
+
+  @patch('spectator_client.time.time')
+  @patch('spectator_client.urllib2.urlopen')
+  def test_scan_by_service_one(self, mock_urlopen, mock_time):
+    now_time = 1.234
+    url = 'http://{0}:7002/spectator-metrics'.format(TEST_HOST)
+    metrics_response = CLOUDDRIVER_RESPONSE_OBJ
+    expect = copy.deepcopy(metrics_response)
+    expect['__host'] = TEST_HOST
+    expect['__port'] = 7002
+    expect['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]
+    }
+
+    text = json.JSONEncoder(encoding='utf-8').encode(metrics_response)
+    mock_http_response = StringIO(text)
+    mock_urlopen.return_value = mock_http_response
+    mock_time.return_value = now_time
+
+    response = self.spectator.scan_by_service(
+        {'clouddriver': {'metrics_url': [url]}})
+    self.assertEquals([(url + self.default_query_params, None)],
+                      self.spectator.requests)
+    self.assertEqual({'clouddriver': [expect]}, response)
+
+  @patch('spectator_client.time.time')
+  @patch('spectator_client.urllib2.urlopen')
+  def test_scan_by_service_two(self, mock_urlopen, mock_time):
+    now_time = 1.234
+    url_one = 'http://FirstHost:7002/spectator/metrics'
+    one_response = CLOUDDRIVER_RESPONSE_OBJ
+    expect_one = copy.deepcopy(one_response)
+    expect_one['__host'] = 'firsthost'
+    expect_one['__port'] = 7002
+    expect_one['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]
+    }
+
+    url_two = 'http://SecondHost:7002/spectator/metrics'
+    two_response = dict(one_response)
+    two_response['random'] = 'A distinguishing value'
+    expect_two = dict(expect_one)
+    expect_two['__host'] = 'secondhost'
+    expect_two['random'] = two_response['random']
+
+    text_one = json.JSONEncoder(encoding='utf-8').encode(one_response)
+    text_two = json.JSONEncoder(encoding='utf-8').encode(two_response)
+
+    expect = [expect_one, expect_two]
+    mock_urlopen.side_effect = [StringIO(text_one), StringIO(text_two)]
+    mock_time.return_value = now_time
+
+    response = self.spectator.scan_by_service(
+        {'clouddriver': {'metrics_url': [url_one, url_two]}})
+    self.assertEquals(
+      [
+          ('http://firsthost:7002/spectator/metrics{0}'
+             .format(self.default_query_params), None),
+          ('http://secondhost:7002/spectator/metrics{0}'
+             .format(self.default_query_params), None)
+      ],
+      self.spectator.requests)
+
+    self.assertEqual({'clouddriver': expect}, response)
+
+  @patch('spectator_client.time.time')
+  @patch('spectator_client.urllib2.urlopen')
+  def test_scan_by_service_list(self, mock_urlopen, mock_time):
+    now_time = 1.234
+    clouddriver_url = 'http://{0}:7002/spectator/metrics'.format(TEST_HOST)
+    clouddriver_response = CLOUDDRIVER_RESPONSE_OBJ
+    expect_clouddriver = copy.deepcopy(clouddriver_response)
+    expect_clouddriver['__host'] = TEST_HOST
+    expect_clouddriver['__port'] = 7002
+    expect_clouddriver['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]
+    }
+
+    gate_url = 'http://{0}:8084/spectator/metrics'.format(TEST_HOST)
+    gate_response = GATE_RESPONSE_OBJ
+    expect_gate = copy.deepcopy(gate_response)
+    expect_gate['__host'] = TEST_HOST
+    expect_gate['__port'] = 8084
+    expect_gate['metrics']['spectator.datapoints'] = {
+      'kind': 'Gauge',
+      'values': [{'values': [{'t': int(now_time * 1000), 'v': 4}],
+                  'tags': [{'key': 'success', 'value': 'true'}]}]}
+
+    clouddriver_text = json.JSONEncoder(encoding='utf-8').encode(
+        clouddriver_response)
+    gate_text = json.JSONEncoder(encoding='utf-8').encode(gate_response)
+
+    mock_time.return_value = now_time
+    # The order is sensitive to the order we'll call in.
+    # To get the call order, we'll let the dict tell us,
+    # since that is the order we'll be calling internally.
+    # Ideally this can be specified a different way, but I cant find how.
+    mock_urlopen.side_effect = {'clouddriver': StringIO(clouddriver_text),
+                                'gate': StringIO(gate_text)}.values()
+
+    response = self.spectator.scan_by_service(
+        {'clouddriver': {'metrics_url': [clouddriver_url]},
+         'gate': {'metrics_url': [gate_url]}})
+
+    # Order does not matter.
+    self.assertEquals(
+        sorted([(clouddriver_url + self.default_query_params, None),
+                (gate_url + self.default_query_params, None)]),
+        sorted(self.spectator.requests))
+
+    self.assertEqual({'clouddriver': [expect_clouddriver],
+                      'gate': [expect_gate]},
+                     response)
+
+  def test_service_map_to_type_map_one(self):
+    got = spectator_client.SpectatorClient.service_map_to_type_map(
+      {'clouddriver': [CLOUDDRIVER_RESPONSE_OBJ]})
+    expect = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, expect)
+    self.assertEquals(expect, got)
+
+  def test_service_map_to_type_map_two_different(self):
+    got = spectator_client.SpectatorClient.service_map_to_type_map(
+      {'clouddriver': [CLOUDDRIVER_RESPONSE_OBJ],
+       'gate': [GATE_RESPONSE_OBJ]})
+    expect = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, expect)
+    self.spectator.ingest_metrics(
+        'gate', GATE_RESPONSE_OBJ, expect)
+    self.assertEquals(expect, got)
+
+  def test_service_map_to_type_map_two_same(self):
+    another = dict(CLOUDDRIVER_RESPONSE_OBJ)
+    metric = another['metrics']['jvm.buffer.memoryUsed']['values'][0]
+    metric['values'][0]['t'] = 12345
+    got = spectator_client.SpectatorClient.service_map_to_type_map(
+      {'clouddriver': [CLOUDDRIVER_RESPONSE_OBJ, another]})
+
+    expect = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, expect)
+    self.spectator.ingest_metrics(
+        'clouddriver', another, expect)
+    self.assertEquals(expect, got)
+
+  @patch('spectator_client.urllib2.urlopen')
+  def test_scan_by_type_base_case(self, mock_urlopen):
+    expect = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, expect)
+
+    mock_http_response = StringIO(CLOUDDRIVER_RESPONSE_TEXT)
+    mock_urlopen.return_value = mock_http_response
+
+    url = 'http://{0}:7002/spectator/metrics'.format(TEST_HOST)
+    response = self.spectator.scan_by_type(
+        {'clouddriver': {'metrics_url': [url]}})
+    self.assertEquals([(url + self.default_query_params, None)],
+                      self.spectator.requests)
+    del response['spectator.datapoints']
+    self.assertEqual(expect, response)
+
+  @patch('spectator_client.urllib2.urlopen')
+  def test_scan_by_type_incremental_case(self, mock_urlopen):
+    expect = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, expect)
+    self.spectator.ingest_metrics(
+        'gate', GATE_RESPONSE_OBJ, expect)
+
+    mock_clouddriver_response = StringIO(CLOUDDRIVER_RESPONSE_TEXT)
+    mock_gate_response = StringIO(GATE_RESPONSE_TEXT)
+
+    # The order is sensitive to the order we'll call in.
+    # To get the call order, we'll let the dict tell us,
+    # since that is the order we'll be calling internally.
+    # Ideally this can be specified a different way, but I cant find how.
+    mock_urlopen.side_effect = {'clouddriver': mock_clouddriver_response,
+                                'gate': mock_gate_response}.values()
+
+    clouddriver_url = 'http://{0}:7002/spectator/metrics?a=C'.format(
+        TEST_HOST)
+    gate_url = 'http://{0}:8084/spectator/metrics?gate=YES'.format(
+        TEST_HOST)
+    response = self.spectator.scan_by_type(
+        {'clouddriver': {'metrics_url': [clouddriver_url]},
+         'gate': {'metrics_url': [gate_url]}})
+      
+    self.assertEquals(
+        sorted([(clouddriver_url + '&tagNameRegex=.%2B', None),
+                (gate_url + '&tagNameRegex=.%2B', None)]),
+        sorted(self.spectator.requests))
+
+    del response['spectator.datapoints']
+    self.assertEqual(expect, response)
+
+  def test_ingest_metrics_base_case(self):
+    result = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, result)
+
+    expect = {
+        key: {'clouddriver': [value]}
+        for key, value in CLOUDDRIVER_RESPONSE_OBJ['metrics'].items()
+        }
+
+    self.assertEqual(expect, result)
+
+  def test_ingest_metrics_incremental_case(self):
+    result = {}
+    self.spectator.ingest_metrics(
+        'clouddriver', CLOUDDRIVER_RESPONSE_OBJ, result)
+    self.spectator.ingest_metrics(
+      'gate', GATE_RESPONSE_OBJ, result)
+
+    expect = {key: {'clouddriver': [value]}
+              for key, value
+              in CLOUDDRIVER_RESPONSE_OBJ['metrics'].items()}
+    for key, value in GATE_RESPONSE_OBJ['metrics'].items():
+      if key in expect:
+        expect[key]['gate'] = [value]
+      else:
+        expect[key] = {'gate': [value]}
+
+    self.assertEqual(expect, result)
+
+  def test_filter_name(self):
+    prototype = {'metrics': {'tasks': {}}}
+    expect = {'applicationName': 'clouddriver',
+              'metrics': {
+                  'tasks': CLOUDDRIVER_RESPONSE_OBJ['metrics']['tasks']}}
+    got = self.spectator.filter_metrics(CLOUDDRIVER_RESPONSE_OBJ, prototype)
+    self.assertEqual(expect, got)
+
+  def test_filter_tag(self):
+    prototype = {
+      'metrics': {
+        'jvm.buffer.memoryUsed': {
+          'values': [{
+            'tags': [{'key': 'id', 'value': 'direct'}]
+            }]
+          }
+        }
+      }
+
+    metric = dict(CLOUDDRIVER_RESPONSE_OBJ['metrics']['jvm.buffer.memoryUsed'])
+    metric['values'] = [metric['values'][1]]  # Keep just the one tag set value.
+    expect = {'applicationName': 'clouddriver',
+              'metrics': {'jvm.buffer.memoryUsed': metric}
+             }
+    got = self.spectator.filter_metrics(CLOUDDRIVER_RESPONSE_OBJ, prototype)
+    self.assertEqual(expect, got)
+
+
+if __name__ == '__main__':
+  # pylint: disable=invalid-name
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(SpectatorClientTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
…itoring

I've refactored it a little during the migration so that it
knows about the endpoints to scrape from a "conf_dir" rather than
having built-in names. This will allow easy migration to HA deployments
where there are different name variations and also allows the microservice
debian packages to export their own conf file when installed as a simple
way for the monitoring daemon to know they are present without having to
manually configure.

@jtk54 or @lwander 