### PR TITLE
Migrate basic server infrastructure from spinnaker/google

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 # sudo apt-get install python-dev
 --index-url https://pypi.python.org/simple/
 
+# datadog
+# google-api-python-client
+# oauth2client
 pyyaml
+# prometheus_client
 mock

--- a/spinnaker-monitoring/__main__.py
+++ b/spinnaker-monitoring/__main__.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tool to help support consuming Spinnaker metrics."""
+
+import argparse
+import logging
+import logging.config
+import os
+
+import command_processor
+# import datadog_service
+# import prometheus_service
+import server_handlers
+import spectator_client
+import spectator_handlers
+# import stackdriver_service
+# import stackdriver_handlers
+import util
+
+
+CONFIG_DIR = '/opt/spinnaker_monitor/conf'
+
+
+def init_logging(options):
+  """Initialize logging within this tool."""
+  log_file = options['log_basename'] + '.log'
+  log_dir = options['log_dir']
+
+  log_config = {
+    'version':1,
+    'disable_existing_loggers':True,
+    'formatters': {
+      'timestamped':{
+        'format':'%(asctime)s %(message)s',
+        'datefmt':'%H:%M:%S'
+      }
+    },
+    'handlers':{
+      'console':{
+        'level':'WARNING',
+        'class':'logging.StreamHandler',
+        'formatter':'timestamped'
+      },
+      'file':{
+        'level':'DEBUG',
+        'class':'logging.FileHandler',
+        'formatter':'timestamped',
+        'filename': os.path.join(log_dir, log_file),
+        'mode':'w'
+      },
+    },
+    'loggers':{
+       '': {
+         'level':'DEBUG',
+         'handlers':['console', 'file']
+       },
+    }
+  }
+  logging.config.dictConfig(log_config)
+
+
+def add_global_args(parser):
+  """Add global parser options that are independent of the command."""
+  parser.add_argument('--log_basename', default='spinnaker-monitoring')
+  parser.add_argument('--log_dir', default='.')
+  parser.add_argument('--config_dir', default=CONFIG_DIR,
+                      help='Path to base configuration directory.')
+
+
+def main():
+  """The main program sets up the commands then delegates to one of them."""
+  all_command_handlers = []
+  parser = argparse.ArgumentParser(
+      description='Helper tool to interact with Spinnaker deployment metrics.')
+  add_global_args(parser)
+
+  spectator_client.CONFIG_DIR = os.path.join(CONFIG_DIR)
+
+  subparsers = parser.add_subparsers(title='commands', dest='command')
+  spectator_handlers.add_handlers(all_command_handlers, subparsers)
+#  stackdriver_handlers.add_handlers(all_command_handlers, subparsers)
+#  server_handlers.MonitorCommandHandler.register_metric_service_factory(
+#      prometheus_service.PrometheusServiceFactory())
+#  server_handlers.MonitorCommandHandler.register_metric_service_factory(
+#      datadog_service.DatadogServiceFactory())
+#  server_handlers.MonitorCommandHandler.register_metric_service_factory(
+#      stackdriver_service.StackdriverServiceFactory())
+  server_handlers.add_handlers(all_command_handlers, subparsers)
+
+  opts = parser.parse_args()
+  options = vars(opts)
+  init_logging(options)
+  options = util.merge_options_and_yaml_from_path(
+      options, os.path.join(opts.config_dir, 'spinnaker-monitoring.conf'))
+
+  command_processor.process_command(
+      options['command'], options, all_command_handlers)
+
+if __name__ == '__main__':
+  abs_path = os.path.abspath(os.path.dirname(__file__))
+  path_basename = os.path.basename(abs_path)
+  if (   (path_basename == 'spinnaker-monitoring')
+      and(os.path.basename(os.path.dirname(abs_path)) == path_basename)):
+    CONFIG_DIR = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', 'conf.dev'))
+  main()

--- a/spinnaker-monitoring/command_processor.py
+++ b/spinnaker-monitoring/command_processor.py
@@ -1,0 +1,167 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements Command Processor for defining and executing commands.
+
+Commands can be invoked from the command-line and/or web server.
+Some commands may only be one or the other. The URL path indicates the
+URL for web invocation and command name is the command for CLI invocation.
+"""
+
+import collections
+
+
+# Global options are a hack so that the web commands can get them
+# when then need to pass them to object factories.
+_global_options = {}
+
+
+def set_global_options(options):
+  """Sets the global options used as defaults for web server execution."""
+  # pylint: disable=global-statement
+  global _global_options
+  _global_options = dict(options)
+
+
+def get_global_options():
+  """Returns the global options used as defaults for web server execution."""
+  return _global_options
+
+
+CommandDefinition = collections.namedtuple(
+  'CommandDefinition',
+  ['handler', 'url_path', 'command_name', 'command_request', 'description'])
+
+
+# pylint: disable=abstract-class-not-used
+class CommandHandler(object):
+  """The base class for command handlers.
+
+  A handler can have a url_path and/or command_name to plug into the
+  Web and CLI execution processors.
+
+  The handler is a stateless controller. The same instance is reused each time
+  for a given command. Each distinct command has a different handler.
+  """
+
+  @staticmethod
+  def accepts_content_type(request, content_type):
+    if not hasattr(request, 'headers'):
+      return False
+    accept = request.headers.get('accept', None)
+    if not accept:
+      return None
+    return content_type in accept.split(',')
+
+  @property
+  def url_path(self):
+    """The url_path that invokes the command in the HTTP server."""
+    return self.__url_path
+
+  @property
+  def command_name(self):
+    """The name (first argument) that invokes the command from the CLI."""
+    return self.__command_name
+
+  @property
+  def description(self):
+    """For help text."""
+    return self.__description
+
+  def __init__(self, url_path, command_name, description):
+    """Constructs the command."""
+    self.__url_path = url_path
+    self.__command_name = command_name
+    self.__description = description
+
+  def params_to_query(self, params):
+    """Convert a parameter dictionary to URL query parameter suffix."""
+    query_list = ['{0}={1}'.format(key, value) for key, value in params.items()]
+    return '?{0}'.format('&'.join(query_list)) if query_list else ''
+
+  def process_commandline_request(self, options, **kwargs):
+    """Processes the command from a commandline request.
+
+    Output (as opposed to logging) should be emitted using output()
+    so that it can be captured to a file or supressed.
+
+    Args:
+      options: [dict] The commandline arguments passed.
+    """
+    raise NotImplementedError()
+
+  def process_web_request(self, request, path, params, fragment):
+    """Processes the command from an HTTP request.
+
+    Args:
+      request: [HttpRequest] The request.
+      path: [string] The path from the request URL.
+      params: [dict] The query parameters from the request URL.
+      fragment: [string] The fragment from the request URL.
+    """
+    raise NotImplementedError()
+
+  def add_argparser(self, subparsers):
+    """Add specialized argparser for this command.
+
+    Args:
+      subparsers: The subparsers from the argparser parser.
+
+    Returns:
+      A new parser for to add additional custom parameters for this command.
+    """
+    parser = subparsers.add_parser(self.command_name, help=self.description)
+    parser.add_argument('--quiet', default=False, action='store_true',
+                        help='Dont print output to stdout.')
+    parser.add_argument('--output_path', default='',
+                        help='If provided, write command output to this path.')
+    return parser
+
+  def output(self, options, content):
+    """Output content from the command.
+
+    This will write to stdout as well as a file depending
+    on the options.
+
+    Args:
+      options: [dict] The command line parameters.
+      content: [string] The output.
+    """
+    do_print = not options.get('quiet', False)
+    if do_print:
+      print content
+    output_path = options.get('output_path', None)
+
+    if output_path:
+      # pylint: disable=invalid-name
+      with open(options['output_path'], 'w') as f:
+        f.write(content)
+      if do_print:
+        print 'Wrote {0}'.format(output_path)
+
+
+def process_command(command, options, command_registry):
+  """Process the given command.
+
+  Args:
+    command: [string] The name of the command to run.
+    options: [dict] Options for the command.
+    command_registry: [list of CommandDefinition]: Inventory of known commands.
+  """
+  for entry in command_registry:
+    if command == entry.command_name:
+      entry.process_commandline_request(options)
+      return
+
+  raise ValueError('Unknown command "{0}".'.format(command))

--- a/spinnaker-monitoring/http_server.py
+++ b/spinnaker-monitoring/http_server.py
@@ -1,0 +1,112 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements HTTP Server."""
+
+import BaseHTTPServer
+import traceback
+
+
+def build_html_document(body, title=None):
+  """Produces the HTML document wrapper for a text/html response."""
+  title_html = '<h1>{0}</h1>\n'.format(title) if title else ''
+  html = ['<html>', '<head>',
+          '<title>{title}</title>'.format(title=title),
+          '<style>',
+"""
+  body { font-size:10pt }
+  table { font-size:10pt;border-width:none;
+          border-spacing:0px;border-color:#F8F8F8;border-style:solid }
+  th, td { padding:2px;vertical-align:top;
+           border-width:1px;border-color:#F8F8F8;border-style:solid; }
+  th { font-weight:bold;text-align:left;font-family:times }
+  th { color:#666666 }
+  a, a.toggle:link, a.toggle:visited {
+      background-color:#FFFFFF;color:#000099 }
+  a.toggle:hover, a.toggle:active {
+      color:#FFFFFF;background-color:#000099 }
+"""
+          '</style>'
+          '</head>', '<body>',
+          title_html,
+          body,
+          '</body>', '</html>']
+  return '\n'.join(html)
+
+
+class DelegatingRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+  """An HttpServer request handler that delegates to our CommandHandler."""
+
+  def respond(self, code, headers, body=None):
+    """Send response to the HTTP request."""
+    self.send_response(code)
+    for key, value in headers.items():
+      self.send_header(key, value)
+    self.end_headers()
+    if body:
+      self.wfile.write(body)
+
+  def decode_request(self, request):
+    """Extract the URL components from the request."""
+    parameters = {}
+    path, ignore, query = request.partition('?')
+    if not query:
+      return request, parameters, None
+    query, ignore, fragment = query.partition('#')
+
+    for part in query.split('&'):
+      key, ignore, value = part.partition('=')
+      parameters[key] = value
+
+    return path, parameters, fragment
+
+  def do_HEAD(self):
+    """Implements BaseHTTPRequestHandler."""
+    # pylint: disable=invalid-name
+    self.respond(200, {'Content-Type': 'text/html'})
+
+  def do_GET(self):
+    """Implements BaseHTTPRequestHandler."""
+    # pylint: disable=invalid-name
+    path, parameters, fragment = self.decode_request(self.path)
+    offset = len(path)
+    handler = None
+    while handler is None and offset >= 0:
+      handler = HttpServer.PATH_HANDLERS.get(path[0:offset])
+      if handler is None:
+        offset = path.rfind('/', 0, offset)
+
+    if handler is None:
+      self.respond(404, {'Content-Type': 'text/html'}, "Unknown")
+    else:
+      try:
+        handler(self, path, parameters, fragment)
+      except:
+        self.send_error(500, traceback.format_exc())
+        raise
+
+  def log_message(self, msg_format, *args):
+    """Suppress HTTP request logging."""
+    pass
+
+
+class HttpServer(BaseHTTPServer.HTTPServer):
+  """Implements HTTP Server that will delegate to injected request handlers."""
+
+  PATH_HANDLERS = {}
+
+  def __init__(self, port, handlers=None):
+    BaseHTTPServer.HTTPServer.__init__(
+        self, ('localhost', port), DelegatingRequestHandler)
+    HttpServer.PATH_HANDLERS.update(handlers or {})

--- a/spinnaker-monitoring/server_handlers.py
+++ b/spinnaker-monitoring/server_handlers.py
@@ -1,0 +1,248 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements commands that starts the web-server daemon."""
+
+
+import logging
+import threading
+import time
+import traceback
+import http_server
+
+import command_processor
+import spectator_client
+
+
+class HomePageHandler(command_processor.CommandHandler):
+  """Implements the home page for the server.
+
+  This lists all the commands with links to execute them.
+  """
+  def __init__(self, all_handlers, url_path, command_name, description):
+    """Constructor.
+
+    Args:
+      all_handlers: [list of CommandHandler] Determines the page contents.
+        The entries that have url_paths will be displayed.
+    """
+    super(HomePageHandler, self).__init__(url_path, command_name, description)
+    self.__all_handlers = all_handlers
+
+  def process_web_request(self, request, path, params, fragment):
+    """Implements CommandHandler."""
+    query = self.params_to_query(params)
+    rows = [(handler.url_path, handler.description)
+            for handler in self.__all_handlers]
+    row_html = [('<tr>'
+                 '<td><A href="{path}{params}">{path}</A></td>'
+                 '<td>{info}</td>'
+                 '</tr>'.format(path=row[0], params=query, info=row[1]))
+                for row in rows if row[0] is not None]
+
+    html_body = '<table>\n{0}\n</table>'.format('\n'.join(row_html))
+    html_doc = http_server.build_html_document(
+        html_body, title='Spinnaker Metrics Administration')
+    request.respond(200, {'ContentType': 'application/html'}, html_doc)
+
+
+class WebserverCommandHandler(command_processor.CommandHandler):
+  """Implements the embedded Web Server."""
+
+  @property
+  def command_handlers(self):
+    """Return list of CommandHandlers available to the server."""
+    return self.__handler_list
+
+  def __init__(self, handler_list, url_path, command_name, description):
+    """Constructor.
+
+    Args:
+      handler_list: The list of CommandHandlers available to the server.
+        The server will lookup and delegate based on the URL path received.
+    """
+    super(WebserverCommandHandler, self).__init__(
+        url_path, command_name, description)
+    self.__handler_list = handler_list
+
+  def process_commandline_request(self, options):
+    """Implements CommandHandler.
+
+    This starts the server and will run forever.
+    """
+    command_processor.set_global_options(options)
+
+    port = options['port']
+    logging.info('Starting HTTP server on port %d', port)
+    url_path_to_handler = {handler.url_path: handler.process_web_request
+                           for handler in self.__handler_list}
+
+    httpd = http_server.HttpServer(port, url_path_to_handler)
+    httpd.serve_forever()
+
+  def add_argparser(self, subparsers):
+    """Implements CommandHandler."""
+    parser = super(WebserverCommandHandler, self).add_argparser(subparsers)
+    parser.add_argument('--port', default=8008, type=int)
+    spectator_client.SpectatorClient.add_standard_parser_arguments(parser)
+    return parser
+
+
+class MonitorCommandHandler(WebserverCommandHandler):
+  """Runs the embedded Web Server with a metric publishing loop."""
+
+  _service_factories = []
+
+  @staticmethod
+  def register_metric_service_factory(factory):
+    """Add a factory for using a concrete metric service.
+
+    This method should be called before processing commands or add_argparser().
+
+    Args:
+      factory: [obj] Factories are callable objects (options, [CommandHandler])
+          That also have a method "enabled(options)" that determines if the
+          service is enabled or not, and "add_argparser(ArgParser)" for adding
+          command line options.
+    """
+    MonitorCommandHandler._service_factories.append(factory)
+
+  def make_metric_services(self, options):
+    """Create the metric services we'll use to publish metrics to a backend.
+    """
+    service_list = []
+    for factory in MonitorCommandHandler._service_factories:
+      if factory.enabled(options):
+        service_list.append(factory(options, self.command_handlers))
+
+    if service_list:
+      return service_list
+
+    raise ValueError('No metric service specified.')
+
+  def __data_map_to_service_metrics(self, data_map):
+    """Extract raw responses into just the metrics.
+
+    Args:
+      data_map: [dict of list of response dicts] Keyed by service name,
+          whose value is the list of raw response dictionaries.
+    Returns:
+      dictionary keyed by service ame whose value is the list of 'metrics'
+          dictionaries embedded in the original raw response dictionaries.
+    """
+    result = {}
+    for service, metrics in data_map.items():
+      actual_metrics = metrics.get('metrics', None)
+      if actual_metrics is None:
+        logging.error('Unexpected response from "%s"', service)
+      else:
+        result[service] = actual_metrics
+    return result
+
+  def process_commandline_request(self, options, metric_service_list=None):
+    """Impements CommandHandler."""
+
+    if metric_service_list is None:
+      metric_service_list = self.make_metric_services(options)
+
+    daemon = threading.Thread(target=self, name='monitor',
+                              args=(options, metric_service_list))
+    daemon.daemon = True
+    daemon.start()
+    super(MonitorCommandHandler, self).process_commandline_request(options)
+
+  def __call__(self, options, metric_service_list):
+    """This is the actual method that implements the CommandHandler.
+
+    It is put here in a callable so that we can run this in a separate thread.
+    The main thread will be the standard WebServer.
+    """
+    period = options['period']
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    spectator = spectator_client.SpectatorClient(options)
+
+    publishing_services = [service
+                           for service in metric_service_list
+                           if 'publish_metrics' in dir(service)]
+
+    logging.info('Starting Monitor')
+    time_offset = int(time.time())
+    while True:
+      if not publishing_services:
+        # we still need this loop to keep the server running
+        # but the loop doesnt do anything.
+        time.sleep(period)
+        continue
+
+      start = time.time()
+      done = start
+      service_metric_map = spectator.scan_by_service(catalog)
+      collected = time.time()
+
+      for service in publishing_services:
+        try:
+          start_publish = time.time()
+          count = service.publish_metrics(service_metric_map)
+          if count is None:
+            count = 0
+
+          done = time.time()
+          logging.info(
+              'Wrote %d metrics to %s in %d ms + %d ms',
+              count, service.__class__.__name__,
+              (collected - start) * 1000, (done - start_publish) * 1000)
+        except:
+          logging.error(traceback.format_exc())
+          # ignore exception, continue server.
+
+      # Try to align time increments so we always collect around the same time
+      # so that the measurements we report are in even intervals.
+      # There is still going to be jitter on the collection end but we'll at
+      # least always start with a steady rhythm.
+      now = time.time()
+      delta_time = (period - (int(now) - time_offset)) % period
+      if delta_time == 0 and (int(now) == time_offset
+                              or (now - start <= 1)):
+        delta_time = period
+      time.sleep(delta_time)
+
+  def add_argparser(self, subparsers):
+    """Implements CommandHandler."""
+    parser = super(MonitorCommandHandler, self).add_argparser(subparsers)
+    for factory in MonitorCommandHandler._service_factories:
+      factory.add_argparser(parser)
+    parser.add_argument('--period', default=60, type=int)
+    return parser
+
+
+def add_handlers(all_handlers, subparsers):
+  """Registers the commands that run the embedded web server."""
+  all_handlers.append(
+      HomePageHandler(all_handlers, '/', None,
+                      'Home page for Spinnaker metric administration.'))
+
+  handler_list = [
+      MonitorCommandHandler(
+          all_handlers, None, 'monitor',
+          'Run a daemon that monitors Spinnaker services and publishes metrics'
+          ' to a metric service.'),
+      WebserverCommandHandler(
+          all_handlers, None, 'webserver',
+          'Run a daemon that provides a webserver to manually interact with'
+          ' spinnaker services publishing metrics.')
+  ]
+  for handler in handler_list:
+    handler.add_argparser(subparsers)
+    all_handlers.append(handler)

--- a/spinnaker-monitoring/spectator_handlers.py
+++ b/spinnaker-monitoring/spectator_handlers.py
@@ -1,0 +1,448 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import json
+
+import command_processor
+import http_server
+import spectator_client
+
+
+def millis_to_time(millis):
+  """Convert milliseconds to a time string."""
+  return datetime.fromtimestamp(millis / 1000).isoformat('T') + 'Z'
+
+
+def strip_non_html_params(options):
+  """Return a copy of options with only those that are query parameters.
+
+  This is to propagate options in web response URLs.
+  """
+  params = {}
+  for key in ['tagNameRegex', 'tagValueRegex', 'metricNameRegex']:
+    if key in options:
+      params[key] = options[key]
+  return params
+
+
+class BaseSpectatorCommandHandler(command_processor.CommandHandler):
+  def make_spectator_client(self, options):
+    return spectator_client.SpectatorClient(options)
+
+  def add_argparser(self, subparsers):
+    parser = super(BaseSpectatorCommandHandler, self).add_argparser(subparsers)
+    parser.add_argument('--by', default='service',
+                        help='Organize by "service" or by "metric" name.')
+    spectator_client.SpectatorClient.add_standard_parser_arguments(parser)
+    return parser
+
+  def _get_data_map(self, catalog, options):
+    restrict_services = options.get('services', None)
+    if restrict_services:
+      catalog = {service: config
+                 for service, config in catalog.items()
+                 if service in restrict_services.split(',')}
+    spectator = self.make_spectator_client(options)
+
+    by = options.get('by', 'service')
+    if by == 'service':
+      data_map = spectator.scan_by_service(catalog, params=options)
+    else:
+      data_map = spectator.scan_by_type(catalog, params=options)
+    return data_map
+
+
+class DumpMetricsHandler(BaseSpectatorCommandHandler):
+  def process_commandline_request(self, options):
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    data_map = self._get_data_map(catalog, options)
+    json_text = json.JSONEncoder(indent=2).encode(data_map)
+    self.output(options, json_text)
+
+  def process_web_request(self, request, path, params, fragment):
+    options = dict(command_processor.get_global_options())
+    options.update(params)
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    param_services = params.get('services', 'all').split(',')
+    if param_services == ['all']:
+      restricted_catalog = catalog
+    else:
+      restricted_catalog = {key: value
+                            for key, value in catalog.items()
+                            if key in param_services}
+    data_map = self._get_data_map(restricted_catalog, options)
+    body = json.JSONEncoder(indent=2).encode(data_map)
+    request.respond(200, {'ContentType': 'application/json'}, body)
+
+
+class ExploreCustomDescriptorsHandler(BaseSpectatorCommandHandler):
+  """Show all the current descriptors in use, and who is using them."""
+
+  def __get_type_and_tag_map_and_active_services(self, catalog, options):
+    spectator = self.make_spectator_client(options)
+
+    type_map = spectator.scan_by_type(catalog, params=options)
+    service_tag_map, active_services = self.to_service_tag_map(type_map)
+    return type_map, service_tag_map, active_services
+
+  def process_commandline_request(self, options):
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    type_map, service_tag_map, active_services = (
+        self.__get_type_and_tag_map_and_active_services(
+            catalog, options))
+
+    params = strip_non_html_params(options)
+    html = self.to_html(type_map, service_tag_map, active_services, params)
+    html_doc = http_server.build_html_document(
+        html, title='Metric Usage')
+    self.output(options, html_doc)
+
+  def process_web_request(self, request, path, params, fragment):
+    options = dict(command_processor.get_global_options())
+    options.update(params)
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+
+    type_map, service_tag_map, active_services = (
+        self.__get_type_and_tag_map_and_active_services(catalog, options))
+
+    params = strip_non_html_params(options)
+    html = self.to_html(type_map, service_tag_map, active_services, params)
+    html_doc = http_server.build_html_document(
+        html, title='Metric Usage')
+    request.respond(200, {'ContentType': 'text/html'}, html_doc)
+
+  @staticmethod
+  def to_service_tag_map(type_map):
+    service_tag_map = {}
+    active_services = set()
+
+    def process_endpoint_values_helper(key, service, values):
+      if not isinstance(values, dict):
+        return
+      tagged_data = values.get('values', [])
+      for tagged_point in tagged_data:
+        tag_map = {tag['key']: tag['value']
+                   for tag in tagged_point.get('tags')}
+        if not tag_map:
+          tag_map = {None: None}
+        if key not in service_tag_map:
+          service_tag_map[key] = {service: [tag_map]}
+        else:
+          service_map = service_tag_map[key]
+          if service in service_map:
+            service_map[service].append(tag_map)
+          else:
+            service_map[service] = [tag_map]
+
+    for key, entry in sorted(type_map.items()):
+      # pylint: disable=bad-indentation
+      for service, value_list in sorted(entry.items()):
+        active_services.add(service)
+        for value in value_list:
+          process_endpoint_values_helper(key, service, value)
+
+    return service_tag_map, active_services
+
+  @staticmethod
+  def to_tag_service_map(columns, service_tag_map):
+    tag_service_map = {}
+    for service, tags in service_tag_map.items():
+      service_index = columns[service]
+
+      for tag_group in tags:
+        for tag_name, tag_value in tag_group.items():
+          if tag_name not in tag_service_map:
+            tag_service_map[tag_name] = [set() for ignore in columns]
+          tag_service_map[tag_name][service_index].add(tag_value)
+
+    return tag_service_map
+
+  def to_html(self, type_map, service_tag_map, active_services, params=None):
+    header_html = ['<tr>', '<th>Metric</th>', '<th>Label</th>']
+    columns = {}
+    for service_name in sorted(active_services):
+      columns[service_name] = len(columns)
+      header_html.append('<th><A href="/show?services={0}">{0}</A></th>'.format(
+          service_name))
+    header_html.append('</tr>')
+
+    html = ['<table border=1>']
+    html.extend(header_html)
+
+    for type_name, service_tag_map in sorted(service_tag_map.items()):
+      tag_service_map = self.to_tag_service_map(columns, service_tag_map)
+      num_labels = len(tag_service_map)
+
+      row_html = ['<tr>']
+      row_span = ' rowspan={0}'.format(num_labels) if num_labels > 1 else ''
+      query_params = dict(params or {})
+      query_params['meterNameRegex'] = type_name
+      metric_url = '/show{0}'.format(self.params_to_query(query_params))
+      row_html.append(
+          '<td{row_span}><A href="{url}">{type_name}</A></td>'.format(
+              row_span=row_span, url=metric_url, type_name=type_name))
+
+      for label_name, service_values in tag_service_map.items():
+        if label_name is None:
+          row_html.append('<td></td>')
+        else:
+          row_html.append(
+              '<td><A href="/explore?tagNameRegex={0}">{0}</A></td>'.format(
+                  label_name))
+        for value_set in service_values:
+          if value_set == set([None]):
+            row_html.append('<td>n/a</td>')
+          else:
+            row_html.append(
+                '<td>{0}</td>'.format(', '.join(
+                    ['<A href="/explore?tagValueRegex={v}">{v}</A>'.format(
+                        v=value)
+                     for value in sorted(value_set)])))
+        row_html.append('</tr>')
+        html.append(''.join(row_html))
+        row_html = ['<tr>']  # prepare for next row if needed
+
+    html.append('</table>')
+    return '\n'.join(html)
+
+
+class TagValue(object):
+  def __init__(self, tag):
+    self.key = tag['key']
+    self.value = tag['value']
+
+  def __hash__(self):
+    return hash((self.key, self.value))
+
+  def __eq__(self, value):
+    return self.key == value.key and self.value == value.value
+
+  def __repr__(self):
+    return self.__str__()
+
+  def __str__(self):
+    return '{0}={1}'.format(self.key, self.value)
+
+  def as_html(self):
+    return '<code><b>{0}</b>={1}</code>'.format(self.key, self.value)
+
+
+class ShowCurrentMetricsHandler(BaseSpectatorCommandHandler):
+  """Show all the current metric values."""
+
+  def process_commandline_request(self, options):
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    data_map = self._get_data_map(catalog, options)
+    by = options.get('by', 'service')
+    if by == 'service':
+      content_data = self.service_map_to_text(data_map, params=options)
+    else:
+      content_data = self.type_map_to_text(data_map, params=options)
+    self.output(options, content_data)
+
+  def process_web_request(self, request, path, params, fragment):
+    options = dict(command_processor.get_global_options())
+    options.update(params)
+    catalog = spectator_client.get_source_catalog(
+        config_dir=options['config_dir'])
+    data_map = self._get_data_map(catalog, options)
+
+    if self.accepts_content_type(request, 'text/html'):
+      content_type = 'text/html'
+      by_service = self.service_map_to_html
+      by_type = self.type_map_to_html
+    else:
+      content_type = 'text/plain'
+      by_service = self.service_map_to_text
+      by_type = self.type_map_to_text
+
+    by = options.get('by', 'service')
+    if by == 'service':
+      content_data = by_service(data_map, params=params)
+    else:
+      content_data = by_type(data_map, params=params)
+
+    if content_type == 'text/html':
+      body = http_server.build_html_document(
+          content_data, title='Current Metrics')
+    else:
+      body = content_data
+    request.respond(200, {'ContentType': content_type}, body)
+
+  def all_tagged_values(self, value_list):
+    all_values = []
+    for data in value_list:
+      tags = [TagValue(tag) for tag in data.get('tags', [])]
+      all_values.append((tags, data['values']))
+    return all_values
+
+  def data_points_to_td(self, data_points):
+    if len(data_points) == 1:
+      point = data_points[0]
+      return '<td>{time}</td><td>{value}</td>'.format(
+          time=millis_to_time(point['t']), value=point['v'])
+
+      td_html = '<td colspan=2><table>'
+      for point in data_points:
+        td_html += '<tr><td>{time}</td><td>{value}</td></tr>'.format(
+            time=millis_to_time(point['t']),
+            value=point['v'])
+      td_html += '</tr></table></td>'
+      return td_html
+
+  def data_points_to_text(self, data_points):
+    text = []
+    for point in data_points:
+      text.append('{time}  {value}'.format(
+          time=millis_to_time(point['t']),
+          value=point['v']))
+    return ', '.join(text)
+
+  def service_map_to_text(self, service_map, params=None):
+    lines = []
+    def process_metrics_helper(metrics):
+      for key, value in metrics.items():
+        tagged_values = self.all_tagged_values(value.get('values'))
+        parts = ['Service "{0}"'.format(service)]
+        parts.append('  {0}'.format(key))
+
+        for one in tagged_values:
+          tag_list = one[0]
+          tag_text = ', '.join([str(elem) for elem in tag_list])
+          time_values = self.data_points_to_text(one[1])
+          parts.append('    Tags={0}'.format(tag_text))
+          parts.append('    Values={0}'.format(time_values))
+        lines.append('\n'.join(parts))
+
+    for service, entry_list in sorted(service_map.items()):
+      for entry in entry_list or []:
+        process_metrics_helper(entry.get('metrics', {}))
+
+    return '\n\n'.join(lines)
+
+  def service_map_to_html(self, service_map, params=None):
+    column_headers_html = ('<tr><th>Service</th><th>Key</th><th>Tags</th>'
+                           '<th>Timestamp</th><th>Value</th></tr>')
+    result = ['<table>',
+              '<tr><th>Service</th><th>Metric</th>'
+              '<th>Timestamp</th><th>Values</th><th>Labels</th></tr>']
+    def process_metrics_helper(metrics):
+      for key, value in metrics.items():
+          # pylint: disable=bad-indentation
+          tagged_values = self.all_tagged_values(value.get('values'))
+          service_url = '/show{0}'.format(
+              self.params_to_query({'services': service}))
+          metric_url = '/show{0}'.format(
+              self.params_to_query({'meterNameRegex': key}))
+          html = (
+              '<tr>'
+              '<th rowspan={rowspan}><A href="{service_url}">{service}</A></th>'
+              '<th rowspan={rowspan}><A href="{metric_url}">{key}</A></th>'
+              .format(rowspan=len(tagged_values),
+                      service_url=service_url,
+                      service=service,
+                      metric_url=metric_url,
+                      key=key))
+          for one in tagged_values:
+            tag_list = one[0]
+            tag_html = '<br/>'.join([elem.as_html() for elem in tag_list])
+            time_value_td = self.data_points_to_td(one[1])
+            html += '{time_value_td}<td>{tag_list}</td></tr>'.format(
+                time_value_td=time_value_td, tag_list=tag_html)
+            result.append(html)
+            html = '<tr>'
+
+    for service, entry_list in sorted(service_map.items()):
+      for entry in entry_list or []:
+        process_metrics_helper(entry.get('metrics', {}))
+    result.append('</table>')
+    return '\n'.join(result)
+
+  def type_map_to_text(self, type_map, params=None):
+    lines = []
+    def process_values_helper(values):
+      tagged_values = self.all_tagged_values(values)
+      for tag_value in tagged_values:
+        text_key = ', '.join([str(tag) for tag in tag_value[0]])
+        tag_to_service_values[text_key] = (service, tag_value[1])
+
+    for key, entry in sorted(type_map.items()):
+      tag_to_service_values = {}
+      for service, value_list in sorted(entry.items()):
+        for value in value_list:
+          process_values_helper(value.get('values'))
+
+      parts = ['Metric "{0}"'.format(key)]
+      for tags_text, values in sorted(tag_to_service_values.items()):
+        parts.append('  Service "{0}"'.format(values[0]))
+        parts.append('    Value: {0}'.format(
+            self.data_points_to_text(values[1])))
+        parts.append('    Tags: {0}'.format(tags_text))
+      lines.append('\n'.join(parts))
+    return '\n\n'.join(lines)
+
+  def type_map_to_html(self, type_map, params=None):
+    """Helper function to render descriptor usage into text."""
+
+    column_headers_html = ('<tr><th>Key</th><th>Timestamp</th><th>Value</th>'
+                           '<th>Service</th><th>Tags</th></tr>')
+    row_html = []
+    def process_values_helper(values):
+      tagged_values = self.all_tagged_values(values)
+      for tag_value in tagged_values:
+        html_key = '<br/>'.join([tag.as_html() for tag in tag_value[0]])
+        tag_to_service_values[html_key] = (service, tag_value[1])
+
+    for key, entry in sorted(type_map.items()):
+      tag_to_service_values = {}
+      for service, value_list in sorted(entry.items()):
+        for value in value_list or []:
+          process_values_helper(value.get('values'))
+
+      row_html.append('<tr><td rowspan={rowspan}><b>{key}</b></td>'.format(
+          rowspan=len(tag_to_service_values), key=key))
+
+      sep = ''
+      for tags_html, values in sorted(tag_to_service_values.items()):
+        time_value_td = self.data_points_to_td(values[1])
+        row_html.append('{sep}{time_value_td}'
+                        '<td><i>{service}</i></td><td>{tags}</td></tr>'
+                        .format(sep=sep, time_value_td=time_value_td,
+                                service=values[0], tags=tags_html))
+        sep = '<tr>'
+
+    return '<table>\n{header}\n{rows}\n</table>'.format(
+        header=column_headers_html, rows='\n'.join(row_html))
+
+
+def add_handlers(handler_list, subparsers):
+  command_handlers = [
+      ShowCurrentMetricsHandler(
+          '/show', 'show', 'Show current metric JSON for all Spinnaker.'),
+      DumpMetricsHandler(
+          '/dump', 'dump',
+          'Show current raw metric JSON from all the servers.'),
+      ExploreCustomDescriptorsHandler(
+          '/explore', 'explore',
+          'Explore metric type usage across Spinnaker microservices.')
+  ]
+  for handler in command_handlers:
+    handler.add_argparser(subparsers)
+    handler_list.append(handler)

--- a/tests/command_processor_test.py
+++ b/tests/command_processor_test.py
@@ -1,0 +1,66 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+
+import command_processor
+
+
+class CommandProcessorTest(unittest.TestCase):
+  def test_process_command(self):
+    mock_a = mock.Mock()
+    mock_a.command_name = 'CommandA'
+    mock_a.process_commandline_request = mock.Mock()
+    mock_b = mock.Mock()
+    mock_b.command_name = 'CommandB'
+    mock_b.process_commandline_request = mock.Mock()
+    registry = [mock_a, mock_b]
+    options = {}
+
+    command_processor.process_command('CommandB', options, registry)
+    self.assertEquals(0, mock_a.process_commandline_request.call_count)
+    self.assertEquals(1, mock_b.process_commandline_request.call_count)
+    mock_b.process_commandline_request.assert_called_with(options)
+
+  def test_process_command_not_found(self):
+    mock_a = mock.Mock()
+    mock_a.command_name = 'CommandA'
+    with self.assertRaises(ValueError):
+        command_processor.process_command('CommandB', {}, [mock_a])
+
+  def accepts_content_type(self):
+    request = mock.Mock()
+    request.headers = {'accept': 'text/html'}
+    self.assertTrue(CommandHandler.accepts_content_type(request, 'text/html'))
+
+    request.headers = {'accept': 'text/plain,text/html'}
+    self.assertTrue(CommandHandler.accepts_content_type(request, 'text/html'))
+
+  def does_not_implicitly_accept_content_type(self):
+    request = mock.Mock()
+    self.assertFalse(CommandHandler.accepts_content_type(request, 'text/html'))
+
+  def does_not_accept_content_type(self):
+    request = mock.Mock()
+    request.headers = {'accept': 'text/plain'}
+    self.assertFalse(CommandHandler.accepts_content_type(request, 'text/html'))
+
+
+if __name__ == '__main__':
+  # pylint: disable=invalid-name
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(CommandProcessorTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)
+

--- a/tests/server_handlers_test.py
+++ b/tests/server_handlers_test.py
@@ -1,0 +1,67 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+
+import command_processor
+from server_handlers import MonitorCommandHandler
+
+
+class FakeFactory(object):
+  def __init__(self, name):
+    self.__name = name
+    self.called_enabled = 0
+    self.called_create = 0
+    self.instance = mock.Mock()
+    self.handler = mock.Mock()
+
+  def enabled(self, options):
+    self.called_enabled += 1
+    return options.get(self.__name, False)
+
+  def __call__(self, options, handler_list):
+    self.called_create += 1
+    handler_list.append(self.handler)
+    return self.instance
+
+
+class ServerHandlersTest(unittest.TestCase):
+  def test_monitor(self):
+    all_handlers = []
+    monitor_handler = MonitorCommandHandler(
+        all_handlers, '/web/path', 'command_name', 'HELP')
+    factory_a = FakeFactory('serviceA')
+    factory_b = FakeFactory('serviceB')
+    factory_c = FakeFactory('serviceC')
+    MonitorCommandHandler.register_metric_service_factory(factory_a)
+    MonitorCommandHandler.register_metric_service_factory(factory_b)
+    MonitorCommandHandler.register_metric_service_factory(factory_c)
+    list = monitor_handler.make_metric_services({'serviceA': True, 'serviceC': True})
+    self.assertEquals(1, factory_a.called_enabled)
+    self.assertEquals(1, factory_a.called_create)
+    self.assertEquals(1, factory_b.called_enabled)
+    self.assertEquals(0, factory_b.called_create)
+    self.assertEquals(1, factory_c.called_enabled)
+    self.assertEquals(1, factory_c.called_create)
+    self.assertEquals([factory_a.instance, factory_c.instance], list)
+    self.assertEquals([factory_a.handler, factory_c.handler], all_handlers)
+
+
+if __name__ == '__main__':
+  # pylint: disable=invalid-name
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(ServerHandlersTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)
+


### PR DESCRIPTION
I've refactored it a little during the migration so that the
concrete monitoring services are injected in from main rather
than in the server_handler. This is a little cleaner.

This PR does not include any concrete services, but provides
the server infrastructure and spectator interactions.

@jtk54 or @lwander 