### PR TITLE
Configure travis to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - 2.7
+
+install: pip install -r requirements.txt
+script: bash tests/run_tests.sh


### PR DESCRIPTION
@cfieber 
I'm not sure if this is going to work (never did this before)

When I look at this URL, it suggests you(?) might need to enable it for me
https://travis-ci.org/spinnaker/spinnaker-monitoring
