### PR TITLE
Conditionally pip install 3rd party client libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ python:
 
 dist: trusty
 
-install: pip install -r spinnaker-monitoring-daemon/requirements.txt
+install:
+  - pip install -r spinnaker-monitoring-daemon/requirements.txt
+  - pip install -r spinnaker-monitoring-third-party/third_party/datadog/requirements.txt
+  - pip install -r spinnaker-monitoring-third-party/third_party/prometheus/requirements.txt
+  - pip install -r spinnaker-monitoring-third-party/third_party/stackdriver/requirements.txt
+
 script: gradle/buildViaTravis.sh
 
 env:

--- a/install_dev.sh
+++ b/install_dev.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ROOT_DIR=$(dirname $0)
+THIRD_PARTY_DIR="$ROOT_DIR/spinnaker-monitoring-third-party/third_party"
+
+if [[ $# -eq 0 ]] || [[ ! -f "$THIRD_PARTY_DIR/$1"/install.sh ]]; then
+    >&2 echo "Usage: $0  <system> <args>"
+    >&2 echo "       where <system> is one of datadog, prometheus, stackdriver"
+    >&2 echo "       and args depends on the system but is typically empty."
+    exit -1
+fi
+
+# Install third_party service to run as development
+# This will still install and run the external services as root.
+# However it creates a personal $HOME/.spinnaker/spinnaker-monitoring.yml file.
+
+if [[ ! -f $HOME/.spinnaker/spinnaker-monitoring.yml ]]; then
+  mkdir -p $HOME/.spinnaker
+  cp "$ROOT_DIR/spinnaker-monitoring-daemon/spinnaker-monitoring.yml" \
+     "$HOME/.spinnaker/spinnaker-monitoring.yml"
+  chmod 600 "$HOME/.spinnaker/spinnaker-monitoring.yml"
+fi
+
+source "$THIRD_PARTY_DIR/install_helper_functions.sh"
+echo "Using $(find_config_path $ROOT_DIR)"   # Creates as side effect if not present
+
+which=$1
+shift
+sudo DEFAULT_CONFIG_YML_DIR="$DEFAULT_CONFIG_YML_DIR" \
+     "$THIRD_PARTY_DIR/$which/install.sh" \
+     $@
+
+echo "Installing python requirements"
+if [[ ! pip install -r spinnaker-monitoring-daemon/requirements.txt ]]
+    >&2 echo "Could not install spinnaker-monitoring-daemon/requirements.txt"
+    >&2 echo "You might need to sudo it yourself, use virtualenv or install python-pip."
+fi

--- a/spinnaker-monitoring-daemon/requirements.txt
+++ b/spinnaker-monitoring-daemon/requirements.txt
@@ -1,9 +1,21 @@
 # sudo apt-get install python-dev
 --index-url https://pypi.python.org/simple/
 
-datadog
-google-api-python-client
-oauth2client
+# 20170226
+# Moved datadog to the datadog cleint install in third-party
+# because it seems to be corrupting gce image baking.
+# datadog
+
+# Moved google to the stackdriver client install in third-party
+# google-api-python-client
+# oauth2client
+
+# Moved prometheus to the prometheus client install in third-party
+# prometheus_client
+
+
+httplib2
 pyyaml
-prometheus_client
+
+# mock is only needed for tests
 mock

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py
@@ -162,8 +162,13 @@ def set_default_paths():
   elif os.path.exists(dev_path):
     spectator_client.DEFAULT_REGISTRY_DIR = dev_path
 
-  if os.path.exists(yml_path):
-    global DEFAULT_CONFIG_PATH
+  home_yml_path = os.path.join(
+      os.environ.get('HOME', ''), '.spinnaker', 'spinnaker-monitoring.yml')
+
+  global DEFAULT_CONFIG_PATH
+  if os.path.exists(home_yml_path):
+    DEFAULT_CONFIG_PATH = home_yml_path
+  elif os.path.exists(yml_path):
     DEFAULT_CONFIG_PATH = yml_path
 
 

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
@@ -21,7 +21,13 @@ import os
 import re
 import socket
 import traceback
-import datadog
+
+try:
+  import datadog
+  datadog_available = True
+except ImportError:
+  datadog_available = False
+  
 
 import spectator_client
 
@@ -48,6 +54,8 @@ class DatadogMetricsService(object):
 
   def __init__(self, api_key, app_key, host=None):
     """Constructs the object."""
+    if not datadog_available:
+      raise ImportError('You must "pip install datadog" to get the datadog client library.')
     self.__api = None
     self.__host = host
     self.__api_key = api_key

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
@@ -53,16 +53,21 @@ import command_processor
 import spectator_client
 import util
 
-from prometheus_client import (
-    CONTENT_TYPE_LATEST,
-    generate_latest)
+try:
+  from prometheus_client import (
+      CONTENT_TYPE_LATEST,
+      generate_latest)
 
-from prometheus_client.core import (
-    GaugeMetricFamily,
-    CounterMetricFamily,
-    REGISTRY)
+  from prometheus_client.core import (
+      GaugeMetricFamily,
+      CounterMetricFamily,
+      REGISTRY)
 
-from prometheus_client.exposition import push_to_gateway
+  from prometheus_client.exposition import push_to_gateway
+  prometheus_available = True
+except ImportError:
+  prometheus_available = False
+
 
 InstanceRecord = collections.namedtuple(
     'InstanceRecord', ['service', 'netloc', 'tags', 'data'])
@@ -77,6 +82,10 @@ class PrometheusMetricsService(object):
   """
 
   def __init__(self, options):
+    if not prometheus_available:
+      raise ImportError(
+           'You must "pip install prometheus-client" to get the prometheus client library.')
+    
     self.__catalog = spectator_client.get_source_catalog(options)
     self.__spectator = spectator_client.SpectatorClient(options)
     self.__add_metalabels = options.get(

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
@@ -23,13 +23,18 @@ import re
 import traceback
 import urllib2
 
-import apiclient
-from googleapiclient.errors import HttpError
-from oauth2client.client import GoogleCredentials
-from oauth2client.service_account import ServiceAccountCredentials
-
 import spectator_client
 import util
+
+
+try:
+  import apiclient
+  from googleapiclient.errors import HttpError
+  from oauth2client.client import GoogleCredentials
+  from oauth2client.service_account import ServiceAccountCredentials
+  stackdriver_available = True
+except ImportError:
+  stackdriver_available = False
 
 
 # This doesnt belong here, but this library insists on logging
@@ -383,6 +388,10 @@ class StackdriverMetricsService(object):
 
 def make_stub(options):
   """Helper function for making a stub to talk to service."""
+  if not stackdriver_available:
+      raise ImportError(
+           'You must "pip install google-api-python-client oauth2client" to get the stackdriver client library.')
+    
   stackdriver_config = options.get('stackdriver', {})
   credentials_path = options.get('credentials_path', None)
   if credentials_path is None:

--- a/spinnaker-monitoring-third-party/third_party/datadog/requirements.txt
+++ b/spinnaker-monitoring-third-party/third_party/datadog/requirements.txt
@@ -1,0 +1,4 @@
+# sudo apt-get install python-dev
+--index-url https://pypi.python.org/simple/
+
+datadog

--- a/spinnaker-monitoring-third-party/third_party/install_helper_functions.sh
+++ b/spinnaker-monitoring-third-party/third_party/install_helper_functions.sh
@@ -1,0 +1,16 @@
+DEFAULT_CONFIG_YML_DIR=${DEFAULT_CONFIG_YML_DIR:-$(dirname $0)/../../spinnaker-monitoring/daemon}
+function find_config_path() {
+  local dirs_to_search=(\
+       /opt/spinnaker-monitoring \
+       "$HOME/.spinnaker" \
+        "$DEFAULT_CONFIG_YML_DIR")
+  for dir in ${dirs_to_search[@]}; do
+    if [[ -f "$dir/spinnaker-monitoring.yml" ]]; then
+       echo "$dir/spinnaker-monitoring.yml"
+       return
+    fi
+  done
+  echo "/opt/spinnaker-monitoring/spinnaker-monitoring.yml"
+  return
+}
+

--- a/spinnaker-monitoring-third-party/third_party/prometheus/requirements.txt
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/requirements.txt
@@ -1,0 +1,4 @@
+# sudo apt-get install python-dev
+--index-url https://pypi.python.org/simple/
+
+prometheus_client

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/requirements.txt
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/requirements.txt
@@ -1,0 +1,6 @@
+# sudo apt-get install python-dev
+--index-url https://pypi.python.org/simple/
+
+google-api-python-client
+oauth2client
+


### PR DESCRIPTION
Rather than pip installing all the server-specific client libraries
when the daemon is installed, only pip install them when the client
install is activated.

I dont think this is ideal, however works around a bug where
pip installing datadog client library within packer is corrupting
the images.

@jtk54 