### PR TITLE
`exec` python when running spinnaker-monitoring.sh

### DIFF
--- a/spinnaker-monitoring-daemon/bin/spinnaker-monitoring.sh
+++ b/spinnaker-monitoring-daemon/bin/spinnaker-monitoring.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 PYTHONWARNINGS=once \
-python $(dirname $0)/../spinnaker-monitoring "$@"
+exec python $(dirname $0)/../spinnaker-monitoring "$@"


### PR DESCRIPTION
Use `exec` so as to avoid an extraneous bash process sitting around doing nothing.  Currently when I run spinnaker-monitoring.sh, I get this output from systemctl:
```
$ sudo service spinnaker-monitoring status
● spinnaker-monitoring.service - Spinnaker monitoring service
   Loaded: loaded (/lib/systemd/system/spinnaker-monitoring.service; static; vendor preset: enabled)
   Active: active (running) since Fri 2017-05-12 15:52:53 UTC; 2min 48s ago
 Main PID: 8478 (spinnaker-monit)
    Tasks: 3
   Memory: 22.8M
      CPU: 304ms
   CGroup: /system.slice/spinnaker-monitoring.service
           ├─8478 /bin/bash /opt/spinnaker-monitoring/bin/spinnaker-monitoring.sh monitor
           └─8482 python /opt/spinnaker-monitoring/bin/../spinnaker-monitoring monitor
```
The extra bash process does nothing but sit around taking up a couple MB of RAM and also it won't forward kill signals to python process. If you `exec` python, both of these issues go away.