### PR TITLE
fix(prometheus): fix instance selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ var/
 *.pyc
 *~
 .gradle
+.idea
+spinnaker-monitoring.iml

--- a/spinnaker-monitoring-third-party/third_party/prometheus/echo-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/echo-microservice-dashboard.json
@@ -507,7 +507,7 @@
         "multi": false,
         "name": "Instance",
         "options": [],
-        "query": "igor:controller:invocations__count",
+        "query": "echo:controller:invocations__count",
         "refresh": 1,
         "regex": "/instance=\"([^\"]+).*/",
         "sort": 1,

--- a/spinnaker-monitoring-third-party/third_party/prometheus/fiat-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/fiat-microservice-dashboard.json
@@ -425,7 +425,7 @@
             "value": "$__all"
           }
         ],
-        "query": "rosco:controller:invocations__count",
+        "query": "fiat:controller:invocations__count",
         "refresh": 2,
         "regex": "/instance=\"([^\"]+).*/",
         "sort": 1,


### PR DESCRIPTION
Looks like some copy-paste errors got the wrong microservice names in two of the dashboards. Hence, if you tried to select an instance, the graphs all went blank.
Also added .gitignore for IntelliJ IDEA project data.