### PR TITLE
fix(dashboards): Fix stackdriver and prometheus dashboards

### DIFF
--- a/spinnaker-monitoring-third-party/third_party/prometheus/application-drilldown-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/application-drilldown-dashboard.json
@@ -75,10 +75,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Orchestration\", isComplete=\"false\"}[$SamplePeriod])) by (application)",
+              "expr": "sum($Function(orca:stage:invocations{application=~\"$Application\"}[$SamplePeriod])) by (application, type)",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{application}}",
+              "legendFormat": "{{application}}/{{type}}",
               "metric": "",
               "refId": "B",
               "step": 10
@@ -87,7 +87,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Active Orchestrations by Application (orca, $Application)",
+          "title": "Active Stages by Application (orca, $Application)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -119,275 +119,6 @@
             }
           ]
         },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "${DS_SPINNAKER}",
-          "fill": 1,
-          "id": 56,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Orchestration\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (application)",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{application}}",
-              "metric": "",
-              "refId": "C",
-              "step": 10
-            },
-            {
-              "expr": "-1 * sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Orchestration\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (application)",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "ERR {{application}}",
-              "metric": "",
-              "refId": "D",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Orchestrations Completed by Application (orca, $Application)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            }
-          ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Echo",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 217,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "${DS_SPINNAKER}",
-          "fill": 1,
-          "id": 58,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Pipeline\", isComplete=\"false\"}[$SamplePeriod])) by (application)",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{application}}",
-              "metric": "",
-              "refId": "B",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Active Pipelines by Application (orca, $Application)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "${DS_SPINNAKER}",
-          "fill": 1,
-          "id": 59,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Pipeline\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (application)",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{application}}",
-              "metric": "",
-              "refId": "C",
-              "step": 10
-            },
-            {
-              "expr": "-1 * sum($Function(orca:task:invocations{application=~\"$Application\", executionType=\"Pipeline\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (application)",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "ERR {{application}}",
-              "metric": "",
-              "refId": "D",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Pipelines Completed by Application (orca, $Application)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            }
-          ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Orca Pipelines",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 183,
-      "panels": [
         {
           "aliasColors": {},
           "bars": true,
@@ -464,91 +195,13 @@
               "show": true
             }
           ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_SPINNAKER}",
-          "fill": 1,
-          "id": 64,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum($Function(orca:task:invocations:duration{application=~\"$Application\"}[$SamplePeriod])) by (application, cloudProvider, bucket)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{bucket}}/{{cloudProvider}}/{{application}}",
-              "metric": "",
-              "refId": "A",
-              "step": 30
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Task Durations by Application (orca, $Application)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
         }
       ],
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Queues",
+      "title": "Echo",
       "titleSize": "h6"
     },
     {
@@ -1195,7 +848,7 @@
         "multi": false,
         "name": "Application",
         "options": [],
-        "query": "orca:task:invocations",
+        "query": "orca:stage:invocations",
         "refresh": 2,
         "regex": "/application=\"([^\"]+)/",
         "sort": 1,

--- a/spinnaker-monitoring-third-party/third_party/prometheus/front50-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/front50-microservice-dashboard.json
@@ -1113,7 +1113,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "drop_common_labels(front50:storageServiceSupport:cacheAge{instance=~\"$Instance\"}) / 1000",
+              "expr": "front50:storageServiceSupport:cacheAge{instance=~\"$Instance\"} / 1000",
               "intervalFactor": 2,
               "legendFormat": "{{objectType}}",
               "refId": "A",

--- a/spinnaker-monitoring-third-party/third_party/prometheus/minimal-spinnaker-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/minimal-spinnaker-dashboard.json
@@ -407,7 +407,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations{isComplete=\"false\"}[$SamplePeriod])) by (instance, executionType, cloudProvider)",
+              "expr": "sum($Function(orca:stage:invocations{isComplete=\"false\"}[$SamplePeriod])) by (instance, executionType, cloudProvider)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{executionType}}/{{cloudProvider}}/{{instance}}",
@@ -419,7 +419,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Active Tasks per Type/Platform (orca)",
+          "title": "Active Stages per Type/Platform (orca)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -482,7 +482,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations{isComplete=\"true\"}[$SamplePeriod])) by (instance, executionType, cloudProvider)",
+              "expr": "sum($Function(orca:stage:invocations{isComplete=\"true\"}[$SamplePeriod])) by (instance, executionType, cloudProvider)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{executionType}}/{{cloudProvider}}/{{instance}}",
@@ -494,7 +494,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Completed Tasks per Type/Platform (orca)",
+          "title": "Completed Stages per Type/Platform (orca)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -531,7 +531,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Orca Tasks",
+      "title": "Orca Stages",
       "titleSize": "h6"
     },
     {
@@ -567,7 +567,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations:duration{bucket!=\"lt5m\"}[$SamplePeriod])) by (cloudProvider, bucket)",
+              "expr": "sum($Function(orca:stage:invocations:duration{bucket!=\"lt5m\"}[$SamplePeriod])) by (cloudProvider, bucket)",
               "intervalFactor": 2,
               "legendFormat": "{{bucket}}/{{cloudProvider}}",
               "metric": "",
@@ -578,7 +578,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Task Duration > 5m per Time-Bucket/Platform (orca)",
+          "title": "Stage Duration > 5m per Time-Bucket/Platform (orca)",
           "tooltip": {
             "shared": true,
             "sort": 2,

--- a/spinnaker-monitoring-third-party/third_party/prometheus/orca-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/orca-microservice-dashboard.json
@@ -157,11 +157,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations{instance=~\"$Instance\", isComplete=\"false\"}[$SamplePeriod])) by (cloudProvider, executionType)",
+              "expr": "sum($Function(orca:stage:invocations{instance=~\"$Instance\"}[$SamplePeriod])) by (cloudProvider, type)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{executionType}}/{{cloudProvider}}",
+              "legendFormat": "{{type}}/{{cloudProvider}}",
               "metric": "",
               "refId": "B",
               "step": 30
@@ -170,7 +170,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Active Tasks per Type/Platform (orca, $Instance)",
+          "title": "Active Stages per Type/Platform (orca, $Instance)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -327,11 +327,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations{instance=~\"$Instance\", isComplete=\"true\"}[$SamplePeriod])) by (cloudProvider, executionType)",
+              "expr": "sum($Function(orca:stage:invocations:duration{instance=~\"$Instance\"}[$SamplePeriod])) by (cloudProvider, stageType)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{executionType}}/{{cloudProvider}}",
+              "legendFormat": "{{stageType}}/{{cloudProvider}}",
               "metric": "",
               "refId": "C",
               "step": 30
@@ -340,7 +340,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Tasks Completed per Type/Platform (orca, $Instance)",
+          "title": "Stages Completed per Type/Platform (orca, $Instance)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -492,11 +492,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum($Function(orca:task:invocations:duration{instance=~\"$Instance\",bucket!=\"lt5m\"}[$SamplePeriod])) by (application, cloudProvider, bucket)",
+              "expr": "sum($Function(orca:stage:invocations:duration{instance=~\"$Instance\",bucket!=\"lt5m\"}[$SamplePeriod])) by (stageType, cloudProvider, bucket)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{bucket}}/{{cloudProvider}}/{{application}}",
+              "legendFormat": "{{bucket}}/{{cloudProvider}}/{{stageType}}",
               "metric": "",
               "refId": "A",
               "step": 30
@@ -505,7 +505,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Task Durations > 5m per Time-Bucket/Platform (orca, $Instance)",
+          "title": "Stage Durations > 5m per Time-Bucket/Platform (orca, $Instance)",
           "tooltip": {
             "shared": true,
             "sort": 2,

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/front50-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/front50-microservice-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
   "displayName": "Front50 Microservice",
   "root": {
     "rowLayout": {
@@ -13,7 +13,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countShortCircuited\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],
@@ -32,7 +32,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countExceptionsThrown\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/gate-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/gate-microservice-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
   "displayName": "Gate Microservice",
   "root": {
     "rowLayout": {
@@ -13,7 +13,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countShortCircuited\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],
@@ -32,7 +32,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countExceptionsThrown\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/igor-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/igor-microservice-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
   "displayName": "Igor Microservice",
   "root": {
     "rowLayout": {
@@ -13,7 +13,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countShortCircuited\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],
@@ -32,7 +32,7 @@
                   {
                     "timeSeriesFilter": {
                       "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countExceptionsThrown\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
+                      "perSeriesAligner": "ALIGN_NEXT_OLDER"
                     }
                   }
                 ],

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/install.sh
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/install.sh
@@ -112,7 +112,7 @@ if $SERVER; then
 fi
 
 if $DASHBOARDS; then
-  install_dashboards "$@"
+  install_dashboards
 fi
 
 if $CLIENT; then

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/minimal-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/minimal-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
   "displayName": "Minimal Spinnaker Dashboard",
   "root": {
     "gridLayout": {
@@ -11,19 +11,19 @@
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countShortCircuited\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
                 }
               },
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countShortCircuited\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
                 }
               },
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countShortCircuited\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
                 }
               }
             ],
@@ -42,18 +42,37 @@
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countExceptionsThrown\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
                 }
               },
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countExceptionsThrown\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
                 }
               },
               {
                 "timeSeriesFilter": {
                   "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countExceptionsThrown\"",
+                  "perSeriesAligner": "ALIGN_NEXT_OLDER"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Active Stages (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/stage.invocations\"",
                   "perSeriesAligner": "ALIGN_DELTA"
                 }
               }
@@ -67,81 +86,18 @@
           }
         },
         {
-          "title": "Active Orchestrations (orca)",
+          "title": "Completed Stages (orca)",
           "xyChart": {
             "dataSets": [
               {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.isComplete=\"false\" AND metric.label.executionType=\"Orchestration\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                }
-              }
-            ],
-            "constantLines": [
-              {}
-            ],
-            "options": {},
-            "y1Axis": {},
-            "xAxis": {}
-          }
-        },
-        {
-          "title": "Active Pipelines (orca)",
-          "xyChart": {
-            "dataSets": [
-              {
-                "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.isComplete=\"false\" AND metric.label.executionType=\"Pipeline\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                }
-              }
-            ],
-            "constantLines": [
-              {}
-            ],
-            "options": {},
-            "y1Axis": {},
-            "xAxis": {}
-          }
-        },
-        {
-          "title": "Completed Orchestrations (orca)",
-          "xyChart": {
-            "dataSets": [
-              {
-                "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status=\"SUCCEEDED\" AND metric.label.executionType=\"Orchestration\"",
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/stage.invocations.duration\" AND metric.label.status=\"SUCCEEDED\"",
                   "perSeriesAligner": "ALIGN_DELTA"
                 }
               },
               {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status!=\"SUCCEEDED\" AND metric.label.executionType=\"Orchestration\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                }
-              }
-            ],
-            "constantLines": [
-              {}
-            ],
-            "options": {},
-            "y1Axis": {},
-            "xAxis": {}
-          }
-        },
-        {
-          "title": "Completed Pipelines (orca)",
-          "xyChart": {
-            "dataSets": [
-              {
-                "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status=\"SUCCEEDED\" AND metric.label.executionType=\"Pipeline\"",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                }
-              },
-              {
-                "timeSeriesFilter": {
-                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status!=\"SUCCEEDED\" AND metric.label.executionType=\"Pipeline\"",
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/sage.invocations.duration\" AND metric.label.status!=\"SUCCEEDED\"",
                   "perSeriesAligner": "ALIGN_DELTA"
                 }
               }

--- a/spinnaker-monitoring-third-party/third_party/stackdriver/orca-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/stackdriver/orca-microservice-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
   "displayName": "Orca Microservice",
   "root": {
     "rowLayout": {
@@ -87,31 +87,12 @@
         {
           "widgets": [
             {
-              "title": "Active Orchestrations (orca)",
+              "title": "Active Stages (orca)",
               "xyChart": {
                 "dataSets": [
                   {
                     "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Orchestration\" AND metric.label.isComplete=\"false\"",
-                      "perSeriesAligner": "ALIGN_SUM"
-                    }
-                  }
-                ],
-                "constantLines": [
-                  {}
-                ],
-                "options": {},
-                "y1Axis": {},
-                "xAxis": {}
-              }
-            },
-            {
-              "title": "Successful Orchestrations (orca)",
-              "xyChart": {
-                "dataSets": [
-                  {
-                    "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Orchestration\" AND metric.label.isComplete=\"true\" AND metric.label.status=\"SUCCEEDED\"",
+                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/stage.invocations\"",
                       "perSeriesAligner": "ALIGN_DELTA"
                     }
                   }
@@ -125,54 +106,12 @@
               }
             },
             {
-              "title": "Failed Orchestrations (orca)",
+              "title": "Successful Stages (orca)",
               "xyChart": {
                 "dataSets": [
                   {
                     "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Orchestration\" AND metric.label.isComplete=\"true\" AND metric.label.status!=\"SUCCEEDED\"",
-                      "perSeriesAligner": "ALIGN_DELTA"
-                    }
-                  }
-                ],
-                "constantLines": [
-                  {}
-                ],
-                "options": {},
-                "y1Axis": {},
-                "xAxis": {}
-              }
-            }
-          ]
-        },
-        {
-          "widgets": [
-            {
-              "title": "Active Pipelines (orca)",
-              "xyChart": {
-                "dataSets": [
-                  {
-                    "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Pipeline\" AND metric.label.isComplete=\"false\"",
-                      "perSeriesAligner": "ALIGN_SUM"
-                    }
-                  }
-                ],
-                "constantLines": [
-                  {}
-                ],
-                "options": {},
-                "y1Axis": {},
-                "xAxis": {}
-              }
-            },
-            {
-              "title": "Successful Pipelines (orca)",
-              "xyChart": {
-                "dataSets": [
-                  {
-                    "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Pipeline\" AND metric.label.isComplete=\"true\" AND metric.label.status=\"SUCCEEDED\"",
+                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/stage.invocations.duration\" AND metric.label.status=\"SUCCEEDED\"",
                       "perSeriesAligner": "ALIGN_DELTA"
                     }
                   }
@@ -186,12 +125,12 @@
               }
             },
             {
-              "title": "Failed Pipelines (orca)",
+              "title": "Failed Stages (orca)",
               "xyChart": {
                 "dataSets": [
                   {
                     "timeSeriesFilter": {
-                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.executionType=\"Pipeline\" AND metric.label.isComplete=\"true\" AND metric.label.status!=\"SUCCEEDED\"",
+                      "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/stage.invocations.duration\" AND  metric.label.status!=\"SUCCEEDED\"",
                       "perSeriesAligner": "ALIGN_DELTA"
                     }
                   }


### PR DESCRIPTION
cherry-pick of https://github.com/spinnaker/spinnaker-monitoring/pull/70/files

Earlier orca refactoring changed task.invocations metrics.

The stackdriver hystrix metrics in the dashboards thought the
"counter" metrics were counters when in fact they are gauges.