### PR TITLE
feat(spectator):

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
@@ -1,0 +1,471 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transform spectator metrics so they appear different than produced.
+
+This is to allow them to be written into a metric store in a predictable
+way if needed or desired. It also allows letting the metrics appear different
+to refactor the data model without having to make global code changes.
+"""
+
+import collections
+import logging
+import re
+import yaml
+
+class TimestampedMetricValue(
+    collections.namedtuple('TimedstampedMetricValue', ['timestamp', 'value'])):
+  """Represents a value of a particular metric and the time for it.
+
+  This is used to facilite aggregating when we drop tags.
+  """
+  @staticmethod
+  def from_json(data):
+    """Construct TimestampedMetricValue from dictionary in json response."""
+    return TimestampedMetricValue(data['t'], data['v'])
+
+  def aggregate_json(self, data):
+    """Aggregate this value with another value from json response.
+
+    This is used when dropping tags to combine values together.
+    """
+    return TimestampedMetricValue(max(self.timestamp, data['t']),
+                                  self.value + data['v'])
+
+
+class MetricInfo(object):
+  """Manages the value for a specific spectator measurement.
+  """
+  def __init__(self, value_json, sorted_tags):
+    self.__timestamp = value_json['t']
+    self.__value = value_json['v']
+    self.__tags = sorted_tags
+
+  def aggregate_value(self, value_json):
+    """Aggregate another value into this metric."""
+    self.__value += value_json['v']
+    self.__timestamp = max(self.__timestamp, value_json['t'])
+
+  def encode_as_spectator_response(self):
+    """Encode this metric info as a spectator response measurement."""
+    response = {'values': [{'t': self.__timestamp, 'v': self.__value}]}
+    if self.__tags:
+      response['tags'] = self.__tags
+    return response
+
+
+class AggregatedMetricsBuilder(object):
+  """Re-aggregates a collection of metrics to accumulate similar instances.
+
+  This is used to aggregate multiple similar metric samples if tags
+  were removed. Where there used to be multiple distinct metrics from
+  different tag values, there is now a single metric value for the
+  aggregate of what had been partitioned by the removed tag(s).
+
+  The builder will rebuild the collection of metrics based on the
+  unique tag combinations and each combinations aggregate value.
+  The timestamp for each metric will be the most recent timestamp from
+  the individual partitions that went into the aggregate.
+  """
+
+  def __init__(self, discard_tag_values):
+    self.__tags_to_metric = {}
+    self.__discard_tag_values = discard_tag_values
+
+  def add(self, value_json, tags):
+    """Add a measurement to the builder."""
+    def find_tag_value(tag):
+      """Find value for the specified tag, or None."""
+      for elem in tags:
+        if elem['key'] == tag:
+          return elem['value']
+      return None
+
+    if tags:
+      for key, compiled_re in self.__discard_tag_values.items():
+        if compiled_re.match(str(find_tag_value(key))):
+          # ignore this value because it has undesirable tag value.
+          return
+
+    tags = sorted(tags) if tags else None
+    key = str(tags)
+    metric = self.__tags_to_metric.get(key)
+    if not metric:
+      metric = MetricInfo(value_json, tags)
+      self.__tags_to_metric[key] = metric
+    else:
+      metric.aggregate_value(value_json)
+
+  def build(self):
+    """Encode all the measurements for the meter."""
+    return [info.encode_as_spectator_response()
+            for info in self.__tags_to_metric.values()]
+
+
+class SpectatorMetricTransformer(object):
+  """Transform Spectator measurement responses.
+
+  This transforms responses so that the metrics appear to have different
+  definitions than they really did. Typically this means changing
+  the metric name and/or tags, perhaps adding or removing some.
+
+  The transformer applies rules to encoded spectator metrics to produce
+  alternative encodings as if the original spectator metric was the
+  intended metric produced by the rule. This allows the transformer to
+  be easily injected into the processing pipeline from the scrape.
+
+  Rules are keyed by the spectator meter name that they apply to. Therefore,
+  every kept meter needs a distinct rule entry even if the rule is otherwise
+  the same as another.
+
+  Each entry in a rule is optional. Missing entries means "the identity".
+  However the omission of a rule entirely means take the default action
+  on the transformer which is either to discard the metric (default)
+  or keep it as is.
+
+  Transformation rules are as follows:
+    'transform_name': <transform_name_map>
+    'tags': <tag_list>
+    'transform_tags': <tag_transform_list>
+    'add_tags' <added_tag_bindings>
+    'discard_values': <discard_tag_value_list>
+    'per_account': <per_account>
+    'per_application': <per_application>
+
+  where:
+    * <transform_name_map> is a map of <target>: <target_name>
+      which allows the rule to support multiple monitoring systems,
+      where each is given a different name to follow that particular
+      systems naming conventions. The rest of the transform is the same.
+      The <target> is an arbitrary key but should be the system name for
+      readability. The target will be specified by the caller as part of
+      the transform request.
+
+      If the <target_name> is not present but "default" is, then "default"
+      will be used. If a name key is present but empty then the metric will
+      be ignored for that name key. For example if the "default" value is
+      "my-metric" and a "stackdriver" key is empty and you ask for stackdriver,
+      the metric would be ignored, but if you ask for "prometheus" then the
+      name would become the default, "my-metric".
+
+   * <tag_list> is a list of tag names to keep as is. An empty list
+     means none of the tag names will be kept by default. If the
+     'tags' is not specified at all, and no 'transform_tags' are
+     specified then all the tags will be kept by default.
+     The 'statistic' tag is implicitly in this list if present because
+     it is required to interpret the values.
+
+   * <tag_transform_list> is a list of <tag_transform> where <tag_transform> is:
+        'from': <source_tag_name>
+        'to': <target_tag_name_or_names>
+        'type': <type_name_or_names>
+        'compare_value': <compare_string_value>
+        'extract_regex': <extract_regex>
+     where:
+        * <source_tag_name> is the tag in the spectator metric for the value(s)
+        * <target_tag_name_or_names> is either a string or list of strings
+          that specify one or more tags to produce. This can be/include the
+          same <source_tag_name> but the value will be rewritten.
+
+          if the value is a list, then multiple tags will be produced. In this
+          case the <extract_regex> should have a capture group for each
+          element.
+        * <type_name_or_names> is the type for the <target_tag_name_or_names>.
+          This should match the structure of <target_tag_name_or_names>.
+          types are as follows:
+             STRING: the original string value
+             INT: convert the original string value into an integer
+             BOOL: true if it matches the 'compare_value' else false.
+        * <compare_string_value> a string value used to compare against
+          the tag value when converting into a BOOL.
+        * <extract_regex> a regular expression used to extract substrings
+          from the original tag value to produce the new desired tag values.
+   * <added_tag_bindings> is a dictionary of key/value pairs for tags
+     that should be added. The tag values are constants. This is intended
+     to consolidate multiple spectator metrics into a single one using
+     an additional tag to discriminate the value.
+
+   * <discard_tag_value_list> is a list of [transformed] tag values to ignore
+     as if they never happened. The main motivation for this is to strip out
+     certain "statistic" dimensions if they arent needed since these ultimately
+     become other metrics which might not be wanted. The list is dictionary of
+         <tag>: <regex>
+       where
+         <tag> is the target tag name
+         <regex> is a regular expression to match for undesired values.
+
+   * If <per_account> is true, then keep the 'account' tag if present.
+     It is intended that downstream processors on these measurements may
+     break off the account and use it some other way in consideration of
+     its potentially high cardinality.
+
+   * If <per_application> is analogous to <per_account> but for the
+     'application' tag if present.
+
+  When the rule is instantiated in the transformer, it is pre-processed
+  and some additional tags are entered into it for internal use. These
+  internal tags begin with '_'.
+
+  Rules may have additional fields in them for purposes of specifying the
+  target metrics. However these are ignored by the transformer. Some of these
+  in practice are:
+       * 'kind' describes the type of metric (e.g. "Timer")
+       * 'unit' names what is being counted -- the units for the value.
+         Timers are always nanoseconds so the unit is for the "count" part.
+       * 'description' provides documentation on what the metric captures.
+       * 'aggregatable' denotes whether the values can be aggregated across
+         replicas. This is a hint suggesting a value is global so should
+         not be summed across replicas.
+  """
+
+  @staticmethod
+  def new_from_yaml_path(path, **kwargs):
+    """Create new instance using specification in YAML file."""
+    with open(path, 'r') as stream:
+      transform_spec = yaml.load(stream)
+    return SpectatorMetricTransformer(transform_spec, **kwargs)
+
+  @property
+  def default_namespace(self):
+    """Returns the default namespace to use when transforming names."""
+    return self.__default_transform_key
+
+  @property
+  def specification(self):
+    """Returns the specification used to derive the transformer."""
+    return self.__spec
+
+  def __init__(self, spec,
+               default_namespace=None,
+               default_is_identity=False):
+    """Constructor.
+
+    Args:
+      spec: [dict] Transformation specification entry from YAML.
+      default_namespace: [string] The default key to use for transform_name.
+      default_is_identity: [bool] If true and a spec is not
+          found when transforming a metric then assume the identity.
+          otherwise assume the metric should be discarded.
+    """
+    self.__default_transform_key = default_namespace
+    self.__default_rule = ({}                      # identity
+                           if default_is_identity
+                           else None)              # discard
+    self.__spec = spec
+    for rule in spec.values():
+      if rule is None:
+        continue
+
+      # 'statistic' will always be kept implicitly
+      # because it's value affects the semantics of the measurement.
+      # It will ultimately get stripped out when the metrics are
+      # exported into a monitoring system.
+      # Dont explicitly add it to avoid duplication of the implicit add.
+      rule_tags = rule.get('tags', [])
+      if rule_tags:
+        try:
+          del rule_tags[rule_tags.index('statistic')]
+        except ValueError:
+          pass
+
+        if rule.get('per_application'):
+          try:
+            del rule_tags[rule_tags.index('application')]
+          except ValueError:
+            pass
+        if rule.get('per_account'):
+          try:
+            del rule_tags[rule_tags.index('account')]
+          except ValueError:
+            pass
+
+      transform_tags = rule.get('transform_tags', [])
+      rule['_identity_tags'] = (
+          'tags' not in rule and 'transform_tags' not in rule)
+      rule['_added_tags'] = [
+          {'key': key, 'value': value}
+          for key, value in rule.get('add_tags', {}).items()
+      ]
+      for transformation in transform_tags:
+        self.__prepare_transformation(transformation)
+
+      discard_tag_values = rule.get('discard_tag_values', [])
+      if discard_tag_values:
+        rule['_discard_tag_values'] = {
+            key: re.compile(value) for key, value in discard_tag_values.items()
+        }
+
+  def __prepare_transformation(self, transformation):
+    """Update the transformation entry from the YAML to contain functions.
+
+    Args:
+      transformation: [dict] The YAML entry will be augmented with with a
+        '_xform_func' entry that takes the received tag value and returns
+        list of tags. Also an '_identity_tags' that precomputes whether to
+        keep the tags as originally presented.
+
+    Raises:
+      ValueError if the specification was not valid.
+    """
+    from_tag = transformation['from']
+    to_tag = transformation['to']
+    tag_type = transformation['type']
+    if tag_type == 'BOOL':
+      compare = transformation.get('compare_value')
+      if compare:
+        transformation['_xform_func'] = lambda value: {to_tag: value == compare}
+      else:
+        transformation['_xform_func'] = lambda value: {to_tag: value == 'true'}
+      return
+
+    extract_regex = transformation.get('extract_regex')
+    if not extract_regex:
+      if tag_type == 'INT':
+        transformation['_xform_func'] = lambda value: {to_tag: int(value)}
+      elif tag_type == 'STRING':
+        transformation['_xform_func'] = lambda value: {to_tag: value}
+      else:
+        raise ValueError('Unknown tag_type "%s"' % tag_type)
+      return
+
+    extractor = re.compile(extract_regex)
+    to_tags = to_tag if isinstance(to_tag, list) else [to_tag]
+
+    def composite_func(value):
+      """Handle transforming a single tag value into multiple tag values."""
+      matched = extractor.match(value)
+      if not matched:
+        error = ('{tag}: "{pattern}" did not match "{value}"'
+                 .format(tag=from_tag, pattern=extract_regex, value=value))
+        matched_values = transformation.get('default_value')
+        if matched_values:
+          if not isinstance(matched_values, list):
+            matched_values = [matched_values]
+          logging.error(error)
+          logging.warning('Using default value %r', matched_values)
+        else:
+          raise ValueError(error)
+      else:
+        matched_values = matched.groups()
+
+      if len(matched_values) != len(to_tags):
+        raise ValueError('Wrong number of matches: {got} for {tags}'
+                         .format(got=matched_values, tags=to_tags))
+      return {
+          to_tags[index]: matched_values[index] or ''
+          for index in range(len(to_tags))
+      }
+    transformation['_xform_func'] = composite_func
+
+  def process_response(self, metric_response, transform_namespace=None):
+    """Transform the spectator response metrics per the spec."""
+    result = {}
+    for meter_name, spectator_metric in metric_response.items():
+      to_name, to_value = self.process_metric(
+          meter_name, spectator_metric,
+          transform_namespace=transform_namespace)
+      if to_name is None != to_value is None:
+        raise ValueError('Metric "%s" transformed inconsistently'
+                         ' name=%s, value=%s'
+                         % (meter_name, to_name, to_value))
+
+      if to_name is not None:
+        if to_name in result:
+          result[to_name]['values'].extend(to_value['values'])
+        else:
+          result[to_name] = to_value
+    return result
+
+  def process_metric(self, meter_name, spectator_metric,
+                     transform_namespace=None):
+    """Produce the desired Spectator metric from existing one.
+
+    Args:
+      meter_name: [string] The name of the metric
+      spectator_metric: [dict] Individual metric response entry from
+          spectator web endpoint.
+
+    Returns:
+      None if the meter should be ignored
+      Otherwise the transformed metric instance from the spec.
+    """
+    rule = self.__spec.get(meter_name, self.__default_rule)
+    if not rule:
+      if rule is None and not meter_name in self.__spec:
+        # discard if not mentioned and default rule was discard
+        return None, None
+      # identity if not mentioned and default rule was identity
+      # or if was mentioned but no transformations given.
+      return meter_name, spectator_metric
+
+    transformed_name = meter_name
+    name_transform_dict = rule.get('transform_name')
+    if name_transform_dict:
+      transform_namespace = transform_namespace or self.default_namespace
+      if transform_namespace not in name_transform_dict:
+        transform_namespace = 'default'
+      transformed_name = name_transform_dict.get(transform_namespace)
+      if not transformed_name:
+        return None, None
+
+    transformed = {
+        'kind': spectator_metric['kind'],
+        'values': self.__apply_transform_rule(rule, spectator_metric)
+    }
+    return transformed_name, transformed
+
+  def __apply_transform_rule(self, rule, spectator_metric):
+    metric_builder = AggregatedMetricsBuilder(
+        rule.get('_discard_tag_values', {}))
+
+    for source_metric in spectator_metric.get('values', []):
+      source_tags = source_metric.get('tags', [])
+      target_metric = {'values': source_metric['values']}
+      if rule.get('_identity_tags'):
+        target_tags = source_tags + rule['_added_tags']
+      else:
+        tag_dict = {entry['key']: entry['value'] for entry in source_tags}
+        target_tags = list(rule['_added_tags'])
+
+        def add_if_present(key, tag_dict, target_tags):
+          """Add if there is a tag_dict[key] then add it to target_tags."""
+          value = tag_dict.get(key)
+          if value is not None:
+            target_tags.append({'key': key, 'value': value})
+
+        # "statistic" is required to be preserved while transforming.
+        # It will be removed later when the metrics are exported.
+        add_if_present('statistic', tag_dict, target_tags)
+        if rule.get('per_account'):
+          add_if_present('account', tag_dict, target_tags)
+        if rule.get('per_application'):
+          add_if_present('application', tag_dict, target_tags)
+
+        for tag_name in rule.get('tags') or []:
+          target_tags.append({'key': tag_name,
+                              'value': tag_dict.get(tag_name, '')})
+
+        for transformation in rule.get('transform_tags', []):
+          from_tag = transformation['from']
+          value = tag_dict.get(from_tag, '')
+          target_tags.extend(
+              [{'key': key, 'value': value}
+               for key, value in transformation['_xform_func'](value).items()])
+
+      if target_tags:
+        target_metric['tags'] = sorted(target_tags)
+
+      metric_builder.add(target_metric['values'][-1],
+                         target_metric.get('tags'))
+    return metric_builder.build()

--- a/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
+++ b/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
@@ -1,0 +1,529 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=line-too-long
+# pylint: disable=missing-docstring
+
+import copy
+import textwrap
+import unittest
+
+import yaml
+
+from spectator_metric_transformer import SpectatorMetricTransformer
+
+
+# This is a sample spectator response containing
+# a single value for a single measurmement of a 'jvm.memory.used' meter.
+#
+# We'll be using it in many of our tests showing how different transforms
+# apply to it.
+EXAMPLE_MEMORY_USED_RESPONSE = {
+    'jvm.memory.used': {
+        'kind': 'Gauge',
+        'values': [{
+            'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+            'tags': [
+                {'key': 'id', 'value': 'PS Eden Space'},
+                {'key': 'memtype', 'value': 'HEAP'},
+            ]
+        }]
+    }
+}
+
+
+class SpectatorMetricTransformerTest(unittest.TestCase):
+  def do_test(self, spec_yaml, spectator_response, expect_response):
+    spec = yaml.load(spec_yaml)
+    transformer = SpectatorMetricTransformer(
+        spec, default_namespace='stackdriver')
+    got_response = transformer.process_response(spectator_response)
+    for _, got_meter_data in got_response.items():
+      values = got_meter_data.get('values')
+      if values:
+        values.sort()
+    self.assertResponseEquals(expect_response, got_response)
+
+  def assertResponseEquals(self, expect_response, got_response):
+    if expect_response != got_response:
+      print('Expected: %r\n'
+            'Actual:   %r\n'
+            % (expect_response, got_response))
+    self.assertEquals(expect_response, got_response)
+
+  def test_discard_default(self):
+    spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
+    spec = {}
+    transformer = SpectatorMetricTransformer(spec)
+    got_response = transformer.process_response(spectator_response)
+    self.assertResponseEquals({}, got_response)
+
+  def test_identity_default(self):
+    spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
+    spec = {}
+    transformer = SpectatorMetricTransformer(spec, default_is_identity=True)
+    got_response = transformer.process_response(spectator_response)
+    self.assertResponseEquals(spectator_response, got_response)
+
+  def test_identity_explicit(self):
+    spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
+    spec = {'jvm.memory.used': None}
+    transformer = SpectatorMetricTransformer(spec)
+    got_response = transformer.process_response(spectator_response)
+    self.assertResponseEquals(spectator_response, got_response)
+
+  def test_change_meter_name_explicit(self):
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              transform_name:
+                 stackdriver: spinnaker.googleapis.com/java/memory_used
+                 default: memory_used
+        """),
+
+        EXAMPLE_MEMORY_USED_RESPONSE,
+        {'spinnaker.googleapis.com/java/memory_used':
+             EXAMPLE_MEMORY_USED_RESPONSE['jvm.memory.used']}
+    )
+
+  def test_change_meter_name_default(self):
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              transform_name:
+                 default: memory_used
+        """),
+
+        EXAMPLE_MEMORY_USED_RESPONSE,
+        {'memory_used': EXAMPLE_MEMORY_USED_RESPONSE['jvm.memory.used']}
+    )
+
+  def test_discard_meter_by_name(self):
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              transform_name:
+                 stackdriver:
+                 default: memory_used
+        """),
+
+        EXAMPLE_MEMORY_USED_RESPONSE,
+        {}
+    )
+
+  def test_change_tag_names(self):
+    transformed_value = copy.deepcopy(
+        EXAMPLE_MEMORY_USED_RESPONSE['jvm.memory.used'])
+    transformed_value['values'][0]['tags'] = sorted([
+        {'key': 'segment', 'value': 'PS Eden Space'},
+        {'key': 'scope', 'value': 'HEAP'},
+    ])
+
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              transform_name:
+                stackdriver: spinnaker.googleapis.com/java/memory_used
+                default: memory_used
+              transform_tags:
+                - from: memtype
+                  to: scope
+                  type: STRING
+
+                - from: id
+                  to: segment
+                  type: STRING
+        """),
+
+        EXAMPLE_MEMORY_USED_RESPONSE,
+        {'spinnaker.googleapis.com/java/memory_used': transformed_value}
+    )
+
+  def test_add_tags(self):
+    transformed_value = copy.deepcopy(
+        EXAMPLE_MEMORY_USED_RESPONSE['jvm.memory.used'])
+    transformed_value['values'][0]['tags'] = sorted(
+        transformed_value['values'][0]['tags']
+        + [
+            {'key': 'first', 'value': 'FIRST'},
+            {'key': 'T', 'value': True},
+            {'key': 'F', 'value': False},
+            {'key': 'S', 'value': 'true'},
+            {'key': 'numeric', 'value': 123},
+        ])
+
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              add_tags:
+                first: FIRST
+                T: true
+                F: false
+                S: 'true'
+                numeric: 123
+        """),
+
+        EXAMPLE_MEMORY_USED_RESPONSE,
+        {'jvm.memory.used': transformed_value}
+    )
+
+  def test_consolidate_metrics(self):
+    self.do_test(
+        textwrap.dedent("""\
+          storageServiceSupport.autoRefreshTime:
+            kind: Timer
+            transform_name:
+              stackdriver: spinnaker.googleapis.com/front50/cache/refresh
+            tags:
+              - objectType
+              - statistic
+            add_tags:
+              scheduled: false
+
+          storageServiceSupport.scheduledRefreshTime:
+            kind: Timer
+            transform_name:
+              stackdriver: spinnaker.googleapis.com/front50/cache/refresh
+            tags:
+              - objectType
+              - statistic
+            add_tags:
+              scheduled: true
+        """),
+
+        {
+            'storageServiceSupport.autoRefreshTime': {
+                'kind': 'Timer',
+                'values': [{
+                    'values': [{'t': 1540224536920, 'v': 10000.0}],
+                    'tags': [
+                        {'key': 'objectType', 'value': 'PIPELINES'},
+                        {'key': 'statistic', 'value': 'totalTime'},
+                    ]
+                }]},
+            'storageServiceSupport.scheduledRefreshTime': {
+                'kind': 'Timer',
+                'values': [{
+                    'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                    'tags': [
+                        {'key': 'objectType', 'value': 'PIPELINES'},
+                        {'key': 'statistic', 'value': 'totalTime'},
+                    ]
+                }]}
+        },
+
+
+        {'spinnaker.googleapis.com/front50/cache/refresh': {
+            'kind': 'Timer',
+            'values': [{
+                'values': [{'t': 1540224536920, 'v': 10000.0}],
+                'tags': sorted([
+                    {'key': 'objectType', 'value': 'PIPELINES'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'scheduled', 'value': False}
+                ])
+            }, {
+                'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                'tags': sorted([
+                    {'key': 'objectType', 'value': 'PIPELINES'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'scheduled', 'value': True}
+                ])
+            }
+                      ]
+        }},
+    )
+
+  def test_change_tag_to_type_bool(self):
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              tags:
+                - id
+              transform_tags:
+                - from: memtype
+                  to: heap
+                  type: BOOL
+                  compare_value: HEAP
+        """),
+
+        {'jvm.memory.used': {
+            'kind': 'Gauge',
+            'values': sorted([
+                {'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                 'tags': [
+                     {'key': 'id', 'value': 'PS Eden Space'},
+                     {'key': 'memtype', 'value': 'HEAP'},
+                 ]},
+                {'values': [{'t': 1540224536923, 'v': 12345.0}],
+                 'tags': [
+                     {'key': 'id', 'value': 'Code Cache'},
+                     {'key': 'memtype', 'value': 'NON HEAP'},
+                 ]},
+            ])},
+        },
+
+        {'jvm.memory.used': {
+            'kind': 'Gauge',
+            'values': sorted([
+                {'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                 'tags': sorted([
+                     {'key': 'id', 'value': 'PS Eden Space'},
+                     {'key': 'heap', 'value': True},
+                 ])},
+                {'values': [{'t': 1540224536923, 'v': 12345.0}],
+                 'tags': sorted([
+                     {'key': 'id', 'value': 'Code Cache'},
+                     {'key': 'heap', 'value': False},
+                 ])},
+            ])}
+        })
+
+  def test_change_tag_to_type_int(self):
+    self.do_test(
+        textwrap.dedent("""\
+            controller.invocations:
+              tags:
+                - controller
+                - method
+                - statistic
+                - status
+
+              transform_tags:
+                - from: statusCode
+                  to: statusCode
+                  type: INT
+        """),
+
+        {'controller.invocations': {
+            'kind': 'Timer',
+            'values': [
+                {'values': [{'t': 1540318956420, 'v': 300130409.0}],
+                 'tags': [
+                     {'key': 'controller', 'value': 'ClusterController'},
+                     {'key': 'method', 'value': 'getServerGroup'},
+                     {'key': 'statistic', 'value': 'totalTime'},
+                     {'key': 'status', 'value': '2xx'},
+                     {'key': 'statusCode', 'value': '200'},
+                 ]}
+            ]},
+        },
+
+        {'controller.invocations': {
+            'kind': 'Timer',
+            'values': [
+                {'values': [{'t': 1540318956420, 'v': 300130409.0}],
+                 'tags': [
+                     {'key': 'controller', 'value': 'ClusterController'},
+                     {'key': 'method', 'value': 'getServerGroup'},
+                     {'key': 'statistic', 'value': 'totalTime'},
+                     {'key': 'status', 'value': '2xx'},
+                     {'key': 'statusCode', 'value': 200},
+                 ]}
+            ]},
+        },
+    )
+
+  def test_decompose_tag(self):
+    self.do_test(
+        textwrap.dedent("""\
+            executionCount:
+              tags:
+                - status
+
+              transform_tags:
+                - from: agent
+                  to: [provider, account, region, agent]
+                  type: [STRING, STRING, STRING, STRING]
+                  extract_regex: '([^/]+)/(?:([^/]+)/(?:([^/]+)/)?)?(.+)'
+        """),
+
+        {'executionCount': {
+            'kind': 'Counter',
+            'values': sorted([{
+                'values': [{'t': 1540318956422, 'v': 23258.0}],
+                'tags': [
+                    {'key': 'agent',
+                     'value': 'com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider/my-google-account/australia-southeast1/GoogleSubnetCachingAgent'},
+                    {'key': 'status', 'value': 'success'}
+                ]
+            }, {
+                'values': [{'t': 1540318956422, 'v': 9.0}],
+                'tags': [
+                    {'key': 'agent',
+                     'value': 'com.netflix.spinnaker.clouddriver.appengine.provider.AppengineProvider/my-appengine-account/AppenginePlatformApplicationCachingAgent'},
+                    {'key': 'status', 'value': 'failure'},
+                ]
+            },
+                             ])},
+        },
+
+        {'executionCount': {
+            'kind': 'Counter',
+            'values': sorted([{
+                'values': [{'t': 1540318956422, 'v': 23258.0}],
+                'tags': sorted([
+                    {'key': 'provider',
+                     'value': 'com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider'},
+                    {'key': 'account', 'value': 'my-google-account'},
+                    {'key': 'region', 'value': 'australia-southeast1'},
+                    {'key': 'agent', 'value': 'GoogleSubnetCachingAgent'},
+                    {'key': 'status', 'value': 'success'}
+                ])
+            }, {
+                'values': [{'t': 1540318956422, 'v': 9.0}],
+                'tags': sorted([
+                    {'key': 'provider',
+                     'value': 'com.netflix.spinnaker.clouddriver.appengine.provider.AppengineProvider'},
+                    {'key': 'account', 'value': 'my-appengine-account'},
+                    {'key': 'region', 'value': ''},
+                    {'key': 'agent', 'value': 'AppenginePlatformApplicationCachingAgent'},
+                    {'key': 'status', 'value': 'failure'},
+                ])
+            }
+                             ])}
+        })
+
+  def test_remove_tag(self):
+    self.do_test(
+        textwrap.dedent("""\
+            controller.invocations:
+              tags:
+                - controller
+                - method
+                - status
+                # "statistic" is implicit
+        """),
+
+        {'controller.invocations': {
+            'kind': 'Timer',
+            'values': [{
+                'values': [{'t': 12345, 'v': 1111.0}],
+                'tags': [
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'status', 'value': '4xx'},
+                    {'key': 'statusCode', 'value': '400'},
+                ]
+            }, {
+                'values': [{'t': 12346, 'v': 2222.0}],
+                'tags': [
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'status', 'value': '2xx'},
+                    {'key': 'statusCode', 'value': '200'},
+                ]
+            }, {
+                'values': [{'t': 12347, 'v': 4444.0}],
+                'tags': [
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'status', 'value': '4xx'},
+                    {'key': 'statusCode', 'value': '404'},
+                ]
+            }, {
+                'values': [{'t': 12348, 'v': 8888.0}],
+                'tags': [
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'count'},
+                    {'key': 'status', 'value': '4xx'},
+                    {'key': 'statusCode', 'value': '404'},
+                ]
+            },
+                      ]}
+        },
+
+        {'controller.invocations': {
+            'kind': 'Timer',
+            'values': sorted([{
+                'values': [{'t': 12347, 'v': 5555.0}],
+                'tags': sorted([
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'status', 'value': '4xx'},
+                ])
+            }, {
+                'values': [{'t': 12346, 'v': 2222.0}],
+                'tags': sorted([
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'totalTime'},
+                    {'key': 'status', 'value': '2xx'},
+                ])
+            }, {
+                'values': [{'t': 12348, 'v': 8888.0}],
+                'tags': sorted([
+                    {'key': 'controller', 'value': 'ClusterController'},
+                    {'key': 'method', 'value': 'getServerGroup'},
+                    {'key': 'statistic', 'value': 'count'},
+                    {'key': 'status', 'value': '4xx'},
+                ])
+            },
+                             ])},
+        },
+    )
+
+  def test_discard_tag_values(self):
+    self.do_test(
+        textwrap.dedent("""\
+            jvm.memory.used:
+              tags:
+                  - id
+              transform_tags:
+                - from: memtype
+                  to: heap
+                  type: BOOL
+                  compare_value: HEAP
+              discard_tag_values:
+                heap: "(?i)^false$"
+        """),
+
+        {'jvm.memory.used': {
+            'kind': 'Gauge',
+            'values': sorted([{
+                'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                'tags': [
+                    {'key': 'id', 'value': 'PS Eden Space'},
+                    {'key': 'memtype', 'value': 'HEAP'},
+                ]
+            }, {
+                'values': [{'t': 1540224536923, 'v': 12345.0}],
+                'tags': [
+                    {'key': 'id', 'value': 'Code Cache'},
+                    {'key': 'memtype', 'value': 'NON HEAP'},
+                ]
+            },
+                             ])},
+        },
+
+        {'jvm.memory.used': {
+            'kind': 'Gauge',
+            'values': sorted([{
+                'values': [{'t': 1540224536922, 'v': 1489720024.0}],
+                'tags': sorted([
+                    {'key': 'id', 'value': 'PS Eden Space'},
+                    {'key': 'heap', 'value': True},
+                ])
+            },
+                             ])}
+        })
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Added SpectatorMetricTransformer to transform metric name and tags.

This is so we can change the data model without modifying the code.
While in the long run, it would be desireable to just get it right in the code,
it might not be practical or maintainable. This is intended for a few use cases

   1) To support stackdriver built in metrics where we need to change the
      name of the metric into the stackdriver builtin metric

   2) To support monitoring systems with immutable metric schemas, such as
      stackdriver where once created, new labels cannot be added. For this,
      we ignore labels not present and re-aggregate the value as if it was
      never partitioned against the unknown labels to begin with

   3) Make the metrics more readable by imposing a different naming
      scheme that is more consistent and coherent than what evolved in code.
      Ultimately the code should change but doing so has large impact to
      existing alerts and dashboards. Using these transforms, we can provide
      a preview and/or deprecation path.

   4) Clean up the tags by making them more consistent or removing data
      we dont care about. Also breaking apart some composite tags into
      constituent parts.

   5) Ability to remove high cardinality tags if they are not needed
      in order to reduce monitoring costs.


@brandonnelson3 
@ezimanyi 