### PR TITLE
feat(daemon): Integrate SpectatorMetricTransformer

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
@@ -352,8 +352,6 @@ class SpectatorMetricTransformer(object):
         if matched_values:
           if not isinstance(matched_values, list):
             matched_values = [matched_values]
-          logging.error(error)
-          logging.warning('Using default value %r', matched_values)
         else:
           raise ValueError(error)
       else:


### PR DESCRIPTION
This adds knowledge of metric transformations into the spectator_client.
The transformation specifications are piggybacked in the existing metric
filter files using a different path into the yaml files.

@ezimanyi 