### PR TITLE
chore(daemon): Configure whether to use service tags or decorated met…

### DIFF
--- a/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
+++ b/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
@@ -12,6 +12,27 @@ server:
   port: 8008
 
 
+spectator:
+  # Configures how to process ingested spectator metrics
+
+  # Determines whether a "spin_service" tag should be added to each
+  # metric identifying which service is reporting the metric.
+  # By default if this is off then the metric names themselves will
+  # be decorated to the service making them service-specific.
+  inject_service_tag: False
+
+  # Determines whether or not to decorate the spectator metric name
+  # with the service name reporting it. Normally the services report
+  # metrics using generic names. If this is turned on then the service
+  # name will be added to the metric name to make them unique to the
+  # service.
+  #
+  # If left unset this will be the opposite of "inject_service_tag"
+  # because the name is superfluous with the tags but needed to
+  # give context to the metric without the tags.
+  decorate_metric_name: 
+
+
 monitor:
   # The frequency to poll each of the metric sources in the <registry>
   period: 30


### PR DESCRIPTION
…ric names

Currently metrics are mutated to decorate them with the service name.
Each service does this independentally. The metrics are also "normalized"
which consideres the "statistic" tag and decorates the name and removes it
to accomodate the semantic implications of this tag and its value.

Here we make the service name decoration a configuration option as well
as the ability to inject a service tag so that we can use common metrics
distinguished by the service. This policy is per-provider but not per-metric.
To make it per-provider the global normalizing function is put into a
class and instiated per metric provider where the provider can change
configuration. There is not currently any provider-specific configuration
but that could be added in the future if needed.

@benjaminws