### PR TITLE
chore(daemon): Transformations strip account and application tags whe…

### DIFF
--- a/spinnaker-monitoring-daemon/tests/spectator_client_test.py
+++ b/spinnaker-monitoring-daemon/tests/spectator_client_test.py
@@ -205,7 +205,7 @@ class SpectatorClientTest(unittest.TestCase):
   def setUp(self):
     options = {'prototype_path': None,
                'host': TEST_HOST,
-               'metric_filter_dir': None}
+               'metric_filter_dir': '/none'}
     self.spectator = TestableSpectatorClient(options)
     self.default_query_params = '?tagNameRegex=.%2A'  # tagNameRegex=.*
 

--- a/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
+++ b/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
@@ -524,6 +524,51 @@ class SpectatorMetricTransformerTest(unittest.TestCase):
                              ])}
         })
 
+  def test_per_application_removed(self):
+    # Test is we transform into an application tag and have per_application
+    # then the application tag will be removed (and values aggregated).
+    self.do_test(
+        textwrap.dedent("""\
+            executions.started:
+              kind: Counter
+              per_application: true
+              transform_tags:
+                 - from: source
+                   to: application
+                   type: STRING
+              tags:
+                - executionType
+        """),
+
+        {'executions.started': {
+            'kind': 'Counter',
+            'values': sorted([{
+                'values': [{'t': 1540224536922, 'v': 12.0}],
+                'tags': [
+                    {'key': 'source', 'value': 'MyApplication'},
+                    {'key': 'executionType', 'value': 'Pipeline'},
+                ]
+            }, {
+                'values': [{'t': 1540224536923, 'v': 21.0}],
+                'tags': [
+                    {'key': 'source', 'value': 'YourApplication'},
+                    {'key': 'executionType', 'value': 'Pipeline'},
+                ]
+            },
+                             ])},
+        },
+
+        {'executions.started': {
+            'kind': 'Counter',
+            'values': sorted([{
+                'values': [{'t': 1540224536923, 'v': 33.0}],
+                'tags': sorted([
+                    {'key': 'executionType', 'value': 'Pipeline'},
+                ])
+            },
+                             ])}
+        })
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
…n per_*

There is a bunch of refactoring here that reimplements the transformation
processor so that it encapsulates the specification dictionary into a
TransformationRule. It adds the old private keys as attributes to the rule
and moves the manipulation logic from the TransformationProcessor into the rule.
It is mostly not that interesting except there are no longer explicit None rule
entries in the lookup table and instead are empty rules.

The "interesting" part here is that account and application tags are stripped
if per_account or per_application is specified. This was actually stripped before
too if the tags were coming from spectator, but not if they were injected in
a transform_tag rule. Now we do that. The refactoring wasnt needed to add that,
but I thought I was going to do more and the refactoring is better for future
changes so left it.

The problem here is that there is no implementation that actually uses the
per_account or per_application, nor is there a way to turn it on or off.
If those attributes are needed, the per_* can be commented out of the specification
and tags explicitly added where desired (i.e. essentially dont use per_ feature
yet). It is here so I can write the meter specifications as intended long term.

@ezimanyi 