### PR TITLE
fix(stackdriver): make sure poject id is configured from file on eks

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
@@ -169,8 +169,7 @@ class StackdriverMetricsService(object):
     self.__stackdriver_options.update(options.get('stackdriver', {}))
     self.__stub_factory = stub_factory
     self.__stub = None
-    self.__project = options.get('project',
-                                 self.__stackdriver_options.get('project'))
+    self.__project = self.__stackdriver_options.get('project')
 
     options_copy = dict(options)
     spectator_options = options_copy.get('spectator', {})


### PR DESCRIPTION
Should fix https://github.com/spinnaker/spinnaker/issues/3781

I checked the `project` element in options variable has empty string ('') on debugger. I think applicaiton might put it as default when starting. I can't find any code to configure this `project id` by command line parameters.
So I think below code returns the empty string always even if this application read properly the `project id` from file.

```
self.__project = options.get('project',
                                  self.__stackdriver_options.get('project'))
```