### PR TITLE
chore(daemon): Refactored underlying spectator module API.

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
@@ -241,7 +241,7 @@ class DatadogMetricsService(object):
     # counters, timers, distribution summaries, etc are counters.
     # only "Gauge" is a gauge.
     if self.__use_types:
-      primitive_kind = spectator_client.determine_primitive_kind(
+      primitive_kind = self.__spectator_helper.determine_primitive_kind(
           metric_metadata['kind'])
       metric_type = ('gauge'
                      if primitive_kind == spectator_client.GAUGE_PRIMITIVE_KIND

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
@@ -57,8 +57,8 @@ try:
       generate_latest)
 
   from prometheus_client.core import (
-      GaugeMetricFamily,
       CounterMetricFamily,
+      GaugeMetricFamily,
       REGISTRY)
 
   from prometheus_client.exposition import push_to_gateway
@@ -171,7 +171,7 @@ class PrometheusMetricsCollection(object):
         spectator_client.COUNTER_PRIMITIVE_KIND: CounterBuilder,
         spectator_client.GAUGE_PRIMITIVE_KIND: GaugeBuilder
     }
-    primitive_kind = spectator_client.determine_primitive_kind(info.kind)
+    primitive_kind = self.__spectator_helper.determine_primitive_kind(info.kind)
     return kind_to_factory[primitive_kind](metric_name, all_tags)
 
 

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
@@ -449,7 +449,7 @@ class StackdriverMetricsService(object):
                'value': {'doubleValue': e['v']}}
               for e in instance['values']]
 
-    primitive_kind = spectator_client.determine_primitive_kind(
+    primitive_kind = self.__spectator_helper.determine_primitive_kind(
         metric_metadata['kind'])
     if primitive_kind == spectator_client.GAUGE_PRIMITIVE_KIND:
       metric_kind = 'GAUGE'

--- a/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
+++ b/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
@@ -44,9 +44,11 @@ EXAMPLE_MEMORY_USED_RESPONSE = {
 
 
 class SpectatorMetricTransformerTest(unittest.TestCase):
-  def do_test(self, spec_yaml, spectator_response, expect_response):
+  def do_test(self, spec_yaml, spectator_response, expect_response,
+              options=None):
     spec = yaml.load(spec_yaml)
-    transformer = SpectatorMetricTransformer(spec)
+    options = options or {}
+    transformer = SpectatorMetricTransformer(options, spec)
     got_response = transformer.process_response(spectator_response)
     for _, got_meter_data in got_response.items():
       values = got_meter_data.get('values')
@@ -64,21 +66,22 @@ class SpectatorMetricTransformerTest(unittest.TestCase):
   def test_discard_default(self):
     spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
     spec = {}
-    transformer = SpectatorMetricTransformer(spec)
+    transformer = SpectatorMetricTransformer({}, spec)
     got_response = transformer.process_response(spectator_response)
     self.assertResponseEquals({}, got_response)
 
   def test_identity_default(self):
     spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
     spec = {}
-    transformer = SpectatorMetricTransformer(spec, default_is_identity=True)
+    options = {'default_is_identity': True}
+    transformer = SpectatorMetricTransformer(options, spec)
     got_response = transformer.process_response(spectator_response)
     self.assertResponseEquals(spectator_response, got_response)
 
   def test_identity_explicit(self):
     spectator_response = EXAMPLE_MEMORY_USED_RESPONSE
     spec = {'jvm.memory.used': None}
-    transformer = SpectatorMetricTransformer(spec)
+    transformer = SpectatorMetricTransformer({}, spec)
     got_response = transformer.process_response(spectator_response)
     self.assertResponseEquals(spectator_response, got_response)
 
@@ -557,19 +560,21 @@ class SpectatorMetricTransformerTest(unittest.TestCase):
                 ]),
                 '__per_tag_values': {
                     'application': sorted([
-                      {
-                         'values': [{'t': 1540224536922, 'v': 12.0}],
-                         'tags': [
-                             {'key': 'application', 'value': 'MyApplication'},
-                             {'key': 'executionType', 'value': 'Pipeline'}
-                         ]
-                      }, {
-                         'values': [{'t': 1540224536923, 'v': 21.0}],
-                         'tags': [
-                             {'key': 'application', 'value': 'YourApplication'},
-                             {'key': 'executionType', 'value': 'Pipeline'}
-                         ]
-                      }
+                        {
+                            'values': [{'t': 1540224536922, 'v': 12.0}],
+                            'tags': [
+                                {'key': 'application',
+                                 'value': 'MyApplication'},
+                                {'key': 'executionType', 'value': 'Pipeline'}
+                            ]
+                        }, {
+                            'values': [{'t': 1540224536923, 'v': 21.0}],
+                            'tags': [
+                                {'key': 'application',
+                                 'value': 'YourApplication'},
+                                {'key': 'executionType', 'value': 'Pipeline'}
+                            ]
+                        }
                     ]),
                 }}]),
             }


### PR DESCRIPTION
@ezimanyi 

There is also some reformatting in here to make lint happier.
The main point here is to plumb config options down to the transformation rules
so that they will be available to the next PR that will accomodate some deployment-level policies.