### PR TITLE
fix(stackdriver): Fixed summary support compliance

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/spectator_metric_transformer.py
@@ -690,10 +690,10 @@ class SpectatorMetricTransformer(object):
     """This is a hack for internal stackdriver policy compliance."""
     name = _snakeify(name)
     if kind.endswith('Timer'):
-      if name[-1] == 's':
-        name = name[:-1]
-      if not name.endswith('_latency'):
-        name += '_latency'
+      if not name.endswith('_latencies'):
+        if name[-1] == 's':
+          name = name[:-1]
+        name += '_latencies'
     return name
 
   def __init__(self, options, spec):

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/stackdriver_service.py
@@ -472,10 +472,12 @@ class StackdriverMetricsService(object):
         # Summary was either a timer (totalTime) or summary (totalAmount).
         total = raw_value.get('totalTime') or raw_value.get('totalAmount', 0)
         mean = float(total) / float(count) if count else 0
+
+        # Using explicitBuckets with bounds[0] is recommendation of stackdriver.
+        #    linearBuckets {'numFiniteBuckets':1, 'width':1, 'offset':mean}
+        #    also works
         bucketOptions = {
-          'linearBuckets':  {
-            'numFiniteBuckets': 1, 'width': 1, 'offset': mean
-          }
+            'explicitBuckets': {'bounds': [0]}
         }
         distribution_value = {
             'count': count,

--- a/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
+++ b/spinnaker-monitoring-daemon/tests/spectator_metric_transformer_test.py
@@ -298,10 +298,10 @@ class SpectatorMetricTransformerTest(unittest.TestCase):
     do_name = transformer.normalize_meter_name
     self.assertEquals('timers', do_name('timers', 'Gauge'))
     self.assertEquals('timers', do_name('timers', 'Counter'))
-    self.assertEquals('timer_latency', do_name('timer', 'Timer'))
-    self.assertEquals('timer_latency', do_name('timers', 'Timer'))
-    self.assertEquals('timer_latency', do_name('timer_latency', 'Timer'))
-    self.assertEquals('timer_latency', do_name('timerLatency', 'Timer'))
+    self.assertEquals('timer_latencies', do_name('timer', 'Timer'))
+    self.assertEquals('timer_latencies', do_name('timers', 'Timer'))
+    self.assertEquals('timer_latencies', do_name('timer_latencies', 'Timer'))
+    self.assertEquals('timer_latencies', do_name('timerLatencies', 'Timer'))
 
     do_label = transformer.normalize_label_name
     self.assertEquals('status_code', do_label('status_code'))

--- a/spinnaker-monitoring-daemon/tests/stackdriver_service_test.py
+++ b/spinnaker-monitoring-daemon/tests/stackdriver_service_test.py
@@ -119,7 +119,7 @@ class StackdriverMetricsServiceTest(unittest.TestCase):
     self.service = stackdriver_service.StackdriverMetricsService(
         lambda: self.mockStub, self.options)
     bucketOptions = {
-        'linearBuckets': {'numFiniteBuckets': 1, 'offset': 50.25, 'width': 1}
+        'explicitBuckets': {'bounds': [0]}
     }
     self._do_test_add_metric('Timer', 'CUMULATIVE', 'DISTRIBUTION',
                              {'count': 4, 'totalTime': 201},


### PR DESCRIPTION
Name should be "latencies" and use explicitBucket for the singleton value.
@jtk54 