### PR TITLE
Setup script for Prometheus Operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ var/
 .gradle
 .idea
 spinnaker-monitoring.iml
+generated_dashboards

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
@@ -1,0 +1,14 @@
+# Prometheus Operator + Spinnaker
+
+This setup script assumes:
+
+* You've already enabled Prometheus metric store in Spinnaker
+* You've already installed Prometheus Operator to your cluster
+
+## Usage
+
+`./setup.sh <kubeconfig-context>`
+
+provide an optional kubeconfig context to the script to use.
+
+If you don't provide a context, it will use the current kubeconfig context.

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/grafana-dashboard.yaml.template
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/grafana-dashboard.yaml.template
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %DASHBOARD%
+  labels:
+    grafana_dashboard: "true"
+data:

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONTEXT=${1:-$(kubectl config current-context)}
+
+
+echo "Adding the Spinnaker ServiceMonitor to current context: ${CONTEXT}"
+
+kubectl apply -f spinnaker-service-monitor.yaml
+
+
+echo "Generating Grafana dashboard configmaps..."
+
+for filename in $ROOT/../prometheus/*-dashboard.json; do
+  fn_only=$(basename $filename)
+  fn_root="${fn_only%.*}"
+  dest_file="generated_dashboards/${fn_root}.yaml"
+
+  cat grafana-dashboard.yaml.template | sed -e "s/%DASHBOARD%/${fn_root}/" > $dest_file
+  printf "  ${fn_only}: |-\n" >> $dest_file
+
+  cat $filename | sed -e "/\"__inputs\"/,/],/d" \
+      -e "/\"__requires\"/,/],/d" \
+      -e "s/\${DS_SPINNAKER\}/Prometheus/g" \
+      -e "s/^/    /" \
+  >> $dest_file
+done
+
+
+echo "applying dashboards as configmaps to cluster..."
+
+kubectl apply -f generated_dashboards

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/spinnaker-service-monitor.yaml
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/spinnaker-service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: spinnaker-all-metrics
+  labels:
+    app: spin
+    # this label is here to match the prometheus operator serviceMonitorSelector attribute
+    # prometheus.prometheusSpec.serviceMonitorSelector
+    # https://github.com/helm/charts/tree/master/stable/prometheus-operator
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app: spin
+    namespaceSelector:
+      any: true
+  endpoints:
+  # "port" is string only. "targetPort" is integer or string.
+  - targetPort: 8008
+    interval: 10s
+    path: "/prometheus_metrics"


### PR DESCRIPTION
The current Prometheus installation script doesn't support Kubernetes installations, and often when Spinnaker is run on K8s, Prometheus Operator (often kube-prometheus) is used for managing Prometheus.

This PR adds a script that assumes:
* Spinnaker has Prometheus metric store enabled
* Prometheus Operator is installed to the same cluster Spinnaker is on

And the script does the following:
* Add the necessary ServiceMonitor to tell Prometheus to monitor Spinnaker
* Add the Spinnaker Grafana dashboards via the recommended way of applying a configmap to the cluster

Improvements I can make to this:

* [ ] Be more flexible with naming conventions ("Prometheus", "spin")