### PR TITLE
improve prometheus operator setup script

### DIFF
--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
@@ -4,11 +4,10 @@ This setup script assumes:
 
 * You've already enabled Prometheus metric store in Spinnaker
 * You've already installed Prometheus Operator to your cluster
+* Your kubectl context is the cluster what you have Spinnaker + Prometheus Operator installed
 
 ## Usage
 
-`./setup.sh <kubeconfig-context>`
+`./setup.sh <spinnaker-namespace>`
 
-provide an optional kubeconfig context to the script to use.
-
-If you don't provide a context, it will use the current kubeconfig context.
+provide an optional namespace, if you installed Spinnaker in a different namespace than `default` on your cluster.

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/README.md
@@ -4,7 +4,7 @@ This setup script assumes:
 
 * You've already enabled Prometheus metric store in Spinnaker
 * You've already installed Prometheus Operator to your cluster
-* Your kubectl context is the cluster what you have Spinnaker + Prometheus Operator installed
+* Your kubectl context is the cluster where you have Spinnaker + Prometheus Operator installed
 
 ## Usage
 

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
@@ -3,20 +3,20 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONTEXT=$(kubectl config current-context)
 NAMESPACE=${1:-default}
-KUBECTL="kubectl --context ${CONTEXT} --namespace ${NAMESPACE}"
-echo "Using context ${CONTEXT} and namespace ${NAMESPACE}."
+KUBECTL="kubectl --context $CONTEXT --namespace $NAMESPACE"
+echo "Using context $CONTEXT and namespace $NAMESPACE."
 
 echo "Adding the Spinnaker ServiceMonitor..."
 $KUBECTL apply -f spinnaker-service-monitor.yaml
 
 echo "Generating Grafana dashboard configmaps..."
-for filename in $ROOT/../prometheus/*-dashboard.json; do
-  fn_only=$(basename $filename)
+for filename in "$ROOT"/../prometheus/*-dashboard.json; do
+  fn_only=$(basename "$filename")
   fn_root="${fn_only%.*}"
   dest_file="generated_dashboards/${fn_root}.yaml"
 
-  cat grafana-dashboard.yaml.template | sed -e "s/%DASHBOARD%/${fn_root}/" > $dest_file
-  printf "  ${fn_only}: |-\n" >> $dest_file
+  cat grafana-dashboard.yaml.template | sed -e "s/%DASHBOARD%/$fn_root/" > $dest_file
+  printf "  $fn_only: |-\n" >> $dest_file
 
   cat $filename | sed -e "/\"__inputs\"/,/],/d" \
       -e "/\"__requires\"/,/],/d" \

--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-CONTEXT=${1:-$(kubectl config current-context)}
+CONTEXT=$(kubectl config current-context)
+NAMESPACE=${1:-default}
+KUBECTL="kubectl --context ${CONTEXT} --namespace ${NAMESPACE}"
+echo "Using context ${CONTEXT} and namespace ${NAMESPACE}."
 
-
-echo "Adding the Spinnaker ServiceMonitor to current context: ${CONTEXT}"
-
-kubectl apply -f spinnaker-service-monitor.yaml
-
+echo "Adding the Spinnaker ServiceMonitor..."
+$KUBECTL apply -f spinnaker-service-monitor.yaml
 
 echo "Generating Grafana dashboard configmaps..."
-
 for filename in $ROOT/../prometheus/*-dashboard.json; do
   fn_only=$(basename $filename)
   fn_root="${fn_only%.*}"
@@ -26,7 +25,5 @@ for filename in $ROOT/../prometheus/*-dashboard.json; do
   >> $dest_file
 done
 
-
-echo "applying dashboards as configmaps to cluster..."
-
-kubectl apply -f generated_dashboards
+echo "Applying dashboards as configmaps to cluster..."
+$KUBECTL apply -f generated_dashboards


### PR DESCRIPTION
It's important to put the service monitor in the same namespace as Spinnaker, so have that be the optional parameter in the setup script.