### PR TITLE
add uid to prometheus dashboard definitions

### DIFF
--- a/spinnaker-monitoring-third-party/third_party/prometheus/application-drilldown-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/application-drilldown-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/aws-platform-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/aws-platform-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/clouddriver-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/clouddriver-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/echo-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/echo-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/fiat-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/fiat-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/front50-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/front50-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/gate-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/gate-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/google-platform-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/google-platform-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/igor-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/igor-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/kubernetes-platform-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/kubernetes-platform-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/machine-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/machine-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/minimal-spinnaker-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/minimal-spinnaker-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/orca-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/orca-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [

--- a/spinnaker-monitoring-third-party/third_party/prometheus/rosco-microservice-dashboard.json
+++ b/spinnaker-monitoring-third-party/third_party/prometheus/rosco-microservice-dashboard.json
@@ -37,6 +37,7 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
+  "uid": null,
   "links": [],
   "refresh": "30s",
   "rows": [


### PR DESCRIPTION
 so processing scripts can sub their own

This becomes important when you're running grafana across multiple pods. You need to provide a `uid` value so each pod can consistently find it.