### PR TITLE
generate a uid when generating the grafana dashboards for prometheus operator

### DIFF
--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/setup.sh
@@ -14,11 +14,13 @@ for filename in "$ROOT"/../prometheus/*-dashboard.json; do
   fn_only=$(basename "$filename")
   fn_root="${fn_only%.*}"
   dest_file="generated_dashboards/${fn_root}.yaml"
+  uid=$(uuidgen)
 
   cat grafana-dashboard.yaml.template | sed -e "s/%DASHBOARD%/$fn_root/" > $dest_file
   printf "  $fn_only: |-\n" >> $dest_file
 
-  cat $filename | sed -e "/\"__inputs\"/,/],/d" \
+  cat $filename | sed -e "s/\"uid\": null/\"uid\": \"${uid}\"/" \
+    | sed -e "/\"__inputs\"/,/],/d" \
       -e "/\"__requires\"/,/],/d" \
       -e "s/\${DS_SPINNAKER\}/Prometheus/g" \
       -e "s/^/    /" \


### PR DESCRIPTION
With https://github.com/spinnaker/spinnaker-monitoring/pull/213, the prometheus operator setup script should generate a UID when it generates the Grafana dashboards.