### PR TITLE
feat: adds new relic integration

### DIFF
--- a/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
+++ b/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
@@ -45,6 +45,7 @@ monitor:
   # This will be automatically updated by the third_party/*/instal.sh
   # if this file exists when the install is run with client install enabled.
   metric_store:
+#    - newrelic
 #    - datadog
 #    - prometheus
 #    - stackdriver
@@ -106,3 +107,15 @@ stackdriver:
   # rather than the deployment environment. The task will be labeled
   # with the service being monitored.
   generic_task_resources:
+
+newrelic:
+  # the New Relic Insights Insert Key used to upload data to your application
+  insert_key: 
+
+  # an object containing tags to be appended to all uplodaed metrics. 
+  # each list entry has a key:value pair delimited with ':'
+  # For example:
+  # tags:
+  # - Env:Production
+  # or similar
+  tags:

--- a/spinnaker-monitoring-daemon/requirements.txt
+++ b/spinnaker-monitoring-daemon/requirements.txt
@@ -19,3 +19,4 @@ pyyaml
 
 # mock is only needed for tests
 mock
+newrelic-telemetry-sdk

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py
@@ -28,6 +28,7 @@ import command_processor
 import datadog_service
 import datadog_handlers
 import gcp_service_control_service
+import newrelic_service
 import prometheus_service
 import server_handlers
 import spectator_client
@@ -37,6 +38,7 @@ import stackdriver_service
 import stackdriver_handlers
 import util
 
+METRIC_STORES = ['datadog', 'prometheus', 'stackdriver', 'newrelic']
 
 def handle_sigterm(signalnum, stackframe):
   logging.info('Shutting down from SIGTERM')
@@ -122,6 +124,8 @@ def prepare_commands():
       stackdriver_service.StackdriverServiceFactory())
   server_handlers.MonitorCommandHandler.register_metric_service_factory(
       gcp_service_control_service.GcpServiceControlServiceFactory())
+  server_handlers.MonitorCommandHandler.register_metric_service_factory(
+      newrelic_service.NewRelicServiceFactory())
   server_handlers.add_handlers(all_command_handlers, subparsers)
 
   return all_command_handlers, parser
@@ -157,7 +161,7 @@ def main(config_search_path):
   stores = options['monitor'].get('metric_store', [])
   if not isinstance(stores, list):
     stores = [stores]
-  stores.extend([store for store in ['datadog', 'prometheus', 'stackdriver']
+  stores.extend([store for store in METRIC_STORES
                  if options.get('monitor_' + store)])
   options['monitor']['metric_store'] = set(stores)
 

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/newrelic_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/newrelic_service.py
@@ -1,0 +1,116 @@
+# Copyright 2019 New Relic Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import spectator_client
+import logging
+import os
+from newrelic_telemetry_sdk import CountMetric, GaugeMetric, MetricClient
+
+
+class NewRelicMetricsService(object):
+    """A metrics service for interacting with New Relic."""
+
+    def __init__(self, spectator_helper, metric_client, tags, options):
+        self.spectator_helper = spectator_helper
+        self.metric_client = metric_client
+        self.tags = tags
+
+    def parse_metric(self, service, metric_name, metric_instance, metric_data, service_data, metric_list):
+        kind = self.spectator_helper.determine_primitive_kind(
+            metric_data["kind"])
+        for metric_data_value in metric_instance["values"]:
+            tags = self.tags.copy()
+            for tag in metric_instance["tags"]:
+                tags[tag["key"]] = tag["value"]
+            tags["applicationName"] = service_data["applicationName"]
+            tags["applicationVersion"] = service_data["applicationVersion"]
+            interval = metric_data_value["t"] - \
+                service_data["__collectStartTime"]
+            if kind == spectator_client.GAUGE_PRIMITIVE_KIND:
+                metric_list.append(GaugeMetric(
+                    name=metric_name, value=metric_data_value["v"], tags=tags))
+            else:
+                metric_list.append(CountMetric(
+                    name=metric_name, value=metric_data_value["v"], interval_ms=interval, tags=tags))
+
+    def publish_metrics(self, service_metrics):
+        metric_list = []
+        spectator_client.foreach_metric_in_service_map(
+            service_metrics, self.parse_metric, metric_list)
+        # using 1000 as a known-good size, not a theoretical maximum
+        chunk_size = 1000
+        chunks = [metric_list[i:i + chunk_size]
+                  for i in xrange(0, len(metric_list), chunk_size)]
+        for chunk in chunks:
+            response = self.metric_client.send_batch(chunk)
+            response.raise_for_status()
+        return len(metric_list)
+
+
+NEWRELIC_KUBERNETES_METADATA_MAPPING = {
+    "NEW_RELIC_METADATA_KUBERNETES_CLUSTER_NAME": "clusterName",
+    "NEW_RELIC_METADATA_KUBERNETES_NODE_NAME": "nodeName",
+    "NEW_RELIC_METADATA_KUBERNETES_NAMESPACE_NAME": "namespaceName",
+    "NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME": "deploymentName",
+    "NEW_RELIC_METADATA_KUBERNETES_POD_NAME": "podName",
+    "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME": "containerName",
+    "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME": "containerImageName",
+}
+
+
+def extract_tags(options):
+    tags = {}
+    if 'newrelic' in options and 'tags' in options['newrelic']:
+        option_tags = options['newrelic'].get('tags', []) or []
+        for tag in option_tags:
+            if tag.find(":"):
+                tags.update(tag.split(":", 2))
+    for env_var_name, tag_name in NEWRELIC_KUBERNETES_METADATA_MAPPING.iteritems():
+        if env_var_name in os.environ:
+            tags[tag_name] = os.environ[env_var_name]
+
+    return tags
+
+
+def make_new_relic_service(options, spectator_helper=None):
+    spectator_helper = spectator_helper or spectator_client.SpectatorClientHelper(
+        options)
+    if 'newrelic' in options and 'insert_key' in options['newrelic']:
+        insert_key = options['newrelic']['insert_key']
+    elif 'NEWRELIC_INSERT_KEY' in os.environ:
+        insert_key = os.environ['NEWRELIC_INSERT_KEY']
+    else:
+        raise Exception("New Relic is enabled but the config file has no New Relic Insights Insert Key option \n"
+                        "See https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api for details on insert keys")
+    if 'NEWRELIC_HOST' in os.environ:
+        host = os.environ['NEWRELIC_HOST']
+    elif 'newrelic' in options and 'host' in options['newrelic']:
+        host = options['newrelic']['host']
+    else:
+        host = 'metric-api.newrelic.com'
+    tags = extract_tags(options)
+    metric_client = MetricClient(insert_key, host=host)
+    return NewRelicMetricsService(spectator_helper, metric_client, tags, options)
+
+
+class NewRelicServiceFactory(object):
+    def enabled(self, options):
+        return 'newrelic' in options.get('monitor', {}).get('metric_store', [])
+
+    def add_argparser(self, parser):
+        parser.add_argument("--newrelic", default=False, action='store_true',
+                            dest='monitor_newrelic', help='Publish metrics to New Relic')
+
+    def __call__(self, options, command_handlers):
+        return make_new_relic_service(options)

--- a/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
+++ b/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
@@ -1,0 +1,287 @@
+# Copyright 2019 New Relic Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import os
+import unittest
+from mock import patch
+from spectator_client import SpectatorClientHelper
+from newrelic_service import (
+    NewRelicServiceFactory,
+    NewRelicMetricsService,
+    NEWRELIC_KUBERNETES_METADATA_MAPPING,
+)
+from newrelic_telemetry_sdk import MetricClient
+
+
+class MockRequest:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("error " + str(self.status_code))
+
+
+class MockMetricClient:
+    def __init__(self, insert_key, host="metric-api.newrelic.com"):
+        self.insert_key = insert_key or ""
+        self.host = host
+        self.sent_single_items = []
+        self.sent_item_batches = []
+        self.send_should_fail = False
+        self.status_code = 200
+
+    def send_should_have_status_code(self, status_code=200):
+        """ used to set a status code other than 200 for the returned response """
+        self.status_code = status_code
+
+    def send(self, item):
+        """
+        sends a single item and returns a request, storing the item sent in last_item_sent.
+        the object also records all items sent through this method in sent_single_items
+        """
+        self.last_sent_item = item
+        self.sent_single_items.append(item)
+        return MockRequest(self.status_code)
+
+    def send_batch(self, items):
+        self.last_sent_items = items
+        self.sent_item_batches.append(items)
+        return MockRequest(self.status_code)
+
+
+def generate_options(insert_key="abc", host="not-metric-api.newrelic.com", tags=None):
+    options = {
+        "newrelic": {
+            "insert_key": insert_key,
+            "host": host,
+            "tags": tags
+        }
+    }
+    return options
+
+
+def get_gauge_metric():
+    return (
+        {
+            "applicationName": "spinnaker-monitoring",
+            "applicationVersion": "0.0",
+            "__collectStartTime": 0,
+            "metrics": {
+                "metricname": {
+                    "kind": "Gauge",
+                    "values": [
+                        {
+                            "tags": [
+                                {
+                                    "key": "test2",
+                                    "value": "tag2"
+                                }
+                            ],
+                            "values": [
+                                {
+                                    "v": 0.5,
+                                    "t": 890697600
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        [
+                            {
+                                "key": "test",
+                                "value": "tag",
+                            }
+                        ]
+                    ]
+                }
+            }
+        }
+    )
+
+
+def get_non_gauge_metric(kind="Counter"):
+    return (
+        {
+            "applicationName": "spinnaker-monitoring",
+            "applicationVersion": "0.0",
+            "__collectStartTime": 0,
+            "metrics": {
+                "metricname": {
+                    "kind": kind,
+                    "values": [
+                        {
+                            "tags": [
+                                {
+                                    "key": "test2",
+                                    "value": "tag2"
+                                }
+                            ],
+                            "values": [
+                                {
+                                    "v": 0.5,
+                                    "t": 890697600
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                            [
+                                {
+                                    "key": "test",
+                                    "value": "tag",
+                                }
+                            ]
+                    ]
+                }
+            }
+        }
+    )
+
+
+def getKubernetesMetadataValues():
+    return {
+        "NEW_RELIC_METADATA_KUBERNETES_CLUSTER_NAME": "testCluster",
+        "NEW_RELIC_METADATA_KUBERNETES_NODE_NAME": "testNode",
+        "NEW_RELIC_METADATA_KUBERNETES_NAMESPACE_NAME": "testNamespace",
+        "NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME": "testDeployment",
+        "NEW_RELIC_METADATA_KUBERNETES_POD_NAME": "testPod",
+        "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME": "testContainer",
+        "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME": "testImage",
+    }
+
+
+class NewRelicServiceFactoryTest(unittest.TestCase):
+    def setUp(self):
+        self.serviceFactory = NewRelicServiceFactory()
+
+    def test_make_new_relic_service(self):
+        """ test if options are being passed through correctly by checking url of metric client """
+        options = generate_options()
+        service = self.serviceFactory(options, None)
+        metric_client = service.metric_client
+        self.assertIsInstance(metric_client, MetricClient)
+        self.assertEqual(metric_client.url, metric_client.URL_TEMPLATE.format(
+            "not-metric-api.newrelic.com"))
+        self.assertEqual(service.tags, {})
+
+    def test_inject_kubernetes_metadata(self):
+        options = generate_options()
+        with patch.dict('os.environ', getKubernetesMetadataValues()):
+            service = self.serviceFactory(options, None)
+        kubernetes_metadata_values = getKubernetesMetadataValues()
+        for env_var_name, tag_name in NEWRELIC_KUBERNETES_METADATA_MAPPING.iteritems():
+            self.assertEqual(service.tags[tag_name],
+                             kubernetes_metadata_values[env_var_name])
+
+
+class NewRelicMetricsServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.metric_client = MockMetricClient("abc")
+        self.spectator_helper = SpectatorClientHelper({})
+
+    def test_insert_gauge_metric_with_tags(self):
+        """
+        test a large number of attributes that should be passed through to any successfully created metric
+        using a gauge metric with a tags option as a sample
+        """
+        options = generate_options(tags=["abc:def"])
+        tags = {"abc": "def"}
+        service = NewRelicMetricsService(
+            self.spectator_helper, self.metric_client, tags, options)
+        service_metrics = {"spinnaker-monitoring": [get_gauge_metric()]}
+        num_metrics = service.publish_metrics(service_metrics)
+        self.assertEqual(num_metrics, 1)
+        self.assertEqual(len(self.metric_client.sent_item_batches), 1)
+        self.assertEqual(len(self.metric_client.last_sent_items), 1)
+        metric = self.metric_client.last_sent_items[0]
+        self.assertTrue('name' in metric)
+        self.assertEqual(metric['name'], 'metricname')
+        # gauge metrics do not have an interval.ms property but are do not have other identifiers
+        self.assertTrue('interval.ms' not in metric)
+        self.assertTrue('attributes' in metric)
+        self.assertTrue('applicationName' in metric['attributes'])
+        self.assertEqual(metric['attributes']
+                         ['applicationName'], 'spinnaker-monitoring')
+
+        self.assertTrue('abc' in metric['attributes'])
+        self.assertEqual(metric['attributes']
+                         ['abc'], 'def')
+
+        self.assertTrue('value' in metric)
+        self.assertEqual(metric['value'], 0.5)
+
+    def test_insert_gauge_metric_without_tags(self):
+        """
+        test that a metric with no tags option does not have extraneous attributes added
+        """
+        options = generate_options()
+        service = NewRelicMetricsService(
+            self.spectator_helper, self.metric_client, {}, options)
+        service_metrics = {"spinnaker-monitoring": [get_gauge_metric()]}
+        service.publish_metrics(service_metrics)
+        metric = self.metric_client.last_sent_items[0]
+        self.assertEqual(len(metric['attributes'].items()), 3)
+
+    def test_metric_chunking(self):
+        """
+        test that a batch of 2000 metrics is correctly "chunked" into two batches
+        """
+        options = generate_options(tags=["abc:def"])
+        tags = {"abc": "def"}
+        service = NewRelicMetricsService(
+            self.spectator_helper, self.metric_client, tags, options)
+        service_metrics = {
+            "spinnaker-monitoring": [get_gauge_metric() for _ in range(2000)]}
+
+        num_metrics = service.publish_metrics(service_metrics)
+
+        self.assertEqual(num_metrics, 2000)
+        self.assertEqual(len(self.metric_client.last_sent_items), 1000)
+        self.assertEqual(len(self.metric_client.sent_item_batches), 2)
+
+    def test_insert_counter_metric(self):
+        options = generate_options()
+        service = NewRelicMetricsService(
+            self.spectator_helper, self.metric_client, {}, options)
+        service_metrics = {"spinnaker-monitoring":
+                           [get_non_gauge_metric(),
+                            get_non_gauge_metric("DistributionSummary"),
+                            get_non_gauge_metric("Timer")]}
+        num_metrics = service.publish_metrics(service_metrics)
+        self.assertEqual(num_metrics, 3)
+        for metric in self.metric_client.last_sent_items:
+            # all non gauge metrics are inserted as counters so each should have an interval.ms property
+            self.assertEqual(metric['interval.ms'], 890697600)
+
+    def test_propagate_response_error(self):
+        """ test if the metric service correctly raises an exception when the client returns an error """
+        options = generate_options()
+        self.metric_client.send_should_have_status_code(400)
+        service = NewRelicMetricsService(
+            self.spectator_helper, self.metric_client, {}, options)
+        service_metrics = {
+            "spinnaker_monitoring": [get_gauge_metric()]
+        }
+
+        with self.assertRaises(Exception) as context:
+            service.publish_metrics(service_metrics)
+
+        self.assertTrue("error 400" in context.exception)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a New Relic service which can report raw metrics to New Relic insights using the metrics api and the New Relic Python SDK. Includes tests and updates to configuration docs but not a local install script or pre-built dashboards.

We have been running this code in a test Spinnaker cluster for ~1.5 weeks now without issues. We've also built the config into halyard in a branch [here](https://github.com/newrelic-forks/spinnaker-halyard/tree/newrelic-metric-store) for use configuring the monitoring daemon.