### PR TITLE
fix(stackdriver): fix millis_to_time so it works on developer machine…

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/google_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/google_service.py
@@ -209,7 +209,8 @@ class GoogleMonitoringService(object):
 
   @staticmethod
   def millis_to_time(millis):
-    return datetime.fromtimestamp(millis // 1000).isoformat('T') + 'Z'
+    # matches expected format StackdriverSurveyor.__date_format = '%Y-%m-%dT%H:%M:%SZ'
+    return datetime.utcfromtimestamp(millis // 1000).strftime("%Y-%m-%dT%H:%M:%SZ")
 
   @property
   def project(self):


### PR DESCRIPTION
…s that use localized time.

The tests were passing in CI but failing locally. Ensuring the timestamp is using UTC instead of localized time fixes the inconsistency.

Fixes https://github.com/spinnaker/spinnaker/issues/4878
