### PR TITLE
fix(daemon): pin newrelic-telemetry-sdk version + spelling corrections

### DIFF
--- a/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
+++ b/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
@@ -42,7 +42,7 @@ monitor:
   period: 30
 
   # Enable the one you are interested in using by uncommenting it.
-  # This will be automatically updated by the third_party/*/instal.sh
+  # This will be automatically updated by the third_party/*/install.sh
   # if this file exists when the install is run with client install enabled.
   metric_store:
 #    - newrelic
@@ -112,7 +112,7 @@ newrelic:
   # the New Relic Insights Insert Key used to upload data to your application
   insert_key: 
 
-  # an object containing tags to be appended to all uplodaed metrics. 
+  # an object containing tags to be appended to all uploaded metrics. 
   # each list entry has a key:value pair delimited with ':'
   # For example:
   # tags:

--- a/spinnaker-monitoring-daemon/requirements.txt
+++ b/spinnaker-monitoring-daemon/requirements.txt
@@ -19,4 +19,4 @@ pyyaml
 
 # mock is only needed for tests
 mock
-newrelic-telemetry-sdk
+newrelic-telemetry-sdk==0.1.3


### PR DESCRIPTION
Pins the `newrelic-telemetry-sdk` version as it appears there are breaking changes in `0.2.0`.

This PR started with 2 spelling corrections; CI was [failing](https://travis-ci.org/spinnaker/spinnaker-monitoring/builds/611577511?utm_medium=notification&utm_source=github_status) with the following:
```bash
Running ./tests/newrelic_service_test.py
> Building 28% > :spinnaker-monitoring-daemon:test> Building 28% > :spinnaker-monitoring-daemon:test======================================================================
ERROR: test_make_new_relic_service (__main__.NewRelicServiceFactoryTest)
test if options are being passed through correctly by checking url of metric client
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/newrelic_service_test.py", line 177, in test_make_new_relic_service
    self.assertEqual(metric_client.url, metric_client.URL_TEMPLATE.format(
AttributeError: 'MetricClient' object has no attribute 'url'
```

Looking at the commit history from the SDK, it appears a refactor took place since the `newrelic` integration was added. Bumping it back to `0.1.3` to allow for this (and future PRs) to pass.