### PR TITLE
fix(daemon): fix newrelic tagging

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/newrelic_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/newrelic_service.py
@@ -75,7 +75,8 @@ def extract_tags(options):
         option_tags = options['newrelic'].get('tags', []) or []
         for tag in option_tags:
             if tag.find(":"):
-                tags.update(tag.split(":", 2))
+                key, value = tag.split(":", 1)
+                tags[key] = value
     for env_var_name, tag_name in NEWRELIC_KUBERNETES_METADATA_MAPPING.iteritems():
         if env_var_name in os.environ:
             tags[tag_name] = os.environ[env_var_name]

--- a/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
+++ b/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
@@ -169,14 +169,14 @@ class NewRelicServiceFactoryTest(unittest.TestCase):
         self.serviceFactory = NewRelicServiceFactory()
 
     def test_make_new_relic_service(self):
-        """ test if options are being passed through correctly by checking url of metric client """
-        options = generate_options()
+        """ test if options are being passed through correctly by checking url & tags of metric client """
+        options = generate_options(tags=["abc:def"])
         service = self.serviceFactory(options, None)
         metric_client = service.metric_client
         self.assertIsInstance(metric_client, MetricClient)
         self.assertEqual(metric_client.url, metric_client.URL_TEMPLATE.format(
             "not-metric-api.newrelic.com"))
-        self.assertEqual(service.tags, {})
+        self.assertEqual(service.tags, {"abc": "def"})
 
     def test_inject_kubernetes_metadata(self):
         options = generate_options()


### PR DESCRIPTION
Applying tags to the `newrelic` monitoring daemon are not working as expected. Erroring with the following:

```bash
/usr/local/lib/python2.7/pkgutil.py:186: ImportWarning: Not importing directory '/usr/local/lib/python2.7/site-packages/google': missing __init__.py
  file, filename, etc = imp.find_module(subname, path)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/spinnaker-monitoring/bin/__main__.py", line 194, in <module>
    main(search_path)
  File "/opt/spinnaker-monitoring/bin/__main__.py", line 170, in main
    options['command'], options, all_command_handlers)
  File "/opt/spinnaker-monitoring/bin/command_processor.py", line 174, in process_command
    entry.process_commandline_request(options)
  File "/opt/spinnaker-monitoring/bin/server_handlers.py", line 165, in process_commandline_request
    metric_service_list = self.make_metric_services(options)
  File "/opt/spinnaker-monitoring/bin/server_handlers.py", line 135, in make_metric_services
    service_list.append(factory(options, self.command_handlers))
  File "/opt/spinnaker-monitoring/bin/newrelic_service.py", line 116, in __call__
    return make_new_relic_service(options)
  File "/opt/spinnaker-monitoring/bin/newrelic_service.py", line 102, in make_new_relic_service
    tags = extract_tags(options)
  File "/opt/spinnaker-monitoring/bin/newrelic_service.py", line 78, in extract_tags
    tags.update(tag.split(":", 2))
ValueError: dictionary update sequence element #0 has length 3; 2 is required
```

Corrects the parsing/updating of tags and updates tests coverage. 

To reproduce, try setting a tag `hal config metric-stores newrelic edit --tags environment:dev` and deploy, the `monitoring-daemon` containers will error accordingly. As a workaround, one char key/value pairs e.g. `e:d` can be used.

~~**I expect tests will fail for this until #222 is merged.**~~