### PR TITLE
chore(daemon): Update newrelic-telemetry-sdk to v0.2.

### DIFF
--- a/spinnaker-monitoring-daemon/requirements.txt
+++ b/spinnaker-monitoring-daemon/requirements.txt
@@ -19,4 +19,4 @@ pyyaml
 
 # mock is only needed for tests
 mock
-newrelic-telemetry-sdk==0.1.3
+newrelic-telemetry-sdk~=0.2

--- a/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
+++ b/spinnaker-monitoring-daemon/tests/newrelic_service_test.py
@@ -174,8 +174,7 @@ class NewRelicServiceFactoryTest(unittest.TestCase):
         service = self.serviceFactory(options, None)
         metric_client = service.metric_client
         self.assertIsInstance(metric_client, MetricClient)
-        self.assertEqual(metric_client.url, metric_client.URL_TEMPLATE.format(
-            "not-metric-api.newrelic.com"))
+        self.assertEqual(metric_client._pool.host, "not-metric-api.newrelic.com")
         self.assertEqual(service.tags, {"abc": "def"})
 
     def test_inject_kubernetes_metadata(self):


### PR DESCRIPTION
This PR updates the [newrelic-telemetry-sdk](https://github.com/newrelic/newrelic-telemetry-sdk-python) dependency to the latest version.  The update includes a reduced dependency list ([urllib3](https://github.com/urllib3/urllib3) is now the only dependency).

The New Relic SDK follows semantic versioning so no breaking changes (api removals) should be introduced within the ~=0.2 SDK versions.

This PR fixes a test that relied on a variable that is no longer exposed (a breaking change from v0.1->v0.2)

CC @msneeden 