### PR TITLE
fix(datadog): Remove additional service name

### DIFF
--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/datadog_service.py
@@ -255,7 +255,7 @@ class DatadogMetricsService(object):
 
     name = name.replace('/', '.')
     result.append({
-        'metric': '{service}.{name}'.format(service=service, name=name),
+        'metric': name,
         'host': service_metadata['__host'],
         'type': metric_type,
         'points': [(elem['t'] / 1000, elem['v'])


### PR DESCRIPTION
When exporting to DataDog, the metrics name being exported has one more service name being prepended to it. This change removes the code that prepends service name to metric name after normalisation.

Fixes: spinnaker/spinnaker#5311