### PR TITLE
chore(gcb): make the debs buildable on GCB

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,7 @@
+# By default, everything inside .gitignore (as well as the .git directory and
+# the .gitignore file itself) is not uploaded to Google Cloud Build. But the
+# bintray publishing task requires the .git directory to uploaded.
+#
+# Adding this file overrides the default, so everything gets uploaded, but we
+# still want to exclude the large .gradle cache directory.
+.gradle

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.3
+FROM openjdk:8
 MAINTAINER sig-platform@spinnaker.io
 # The save_cache step will fail if these directories don't exist. We don't have
 # any compilation to do, so just do this instead of running gradle to save time.

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ buildscript {
   }
 }
 
+// This empty task just exists so that '-x javadoc' in the debian GCB file won't
+// cause an error
+task javadoc
+
 allprojects {
   group = "com.netflix.spinnaker.monitoring"
   apply plugin: 'spinnaker.project'


### PR DESCRIPTION
Three things:
* We need to add a `.gcloudignore` so that the `.git` directory gets uploaded
* We need to use `openjdk:8` so that we can run gradle
* We need to add an empty `javadoc` task so that we can use `-x javadoc` (since all the debian builds use the same gradle command)