### PR TITLE
 fix(mtls): Add ssl context config when collecting metrics

### DIFF
--- a/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
+++ b/spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml
@@ -36,6 +36,23 @@ spectator:
   # give context to the metric without the tags.
   decorate_metric_name: 
 
+  # Determines wheter to use a particular SSLContext when collecting
+  # metrics. Normally the spectator collects metrics using the default
+  # sslcontext with verification disabled for when using https with
+  # self-signed certificates. If this is enabled, then the spectator
+  # will use a specific SSLContext, validating the endpoint with a
+  # specific cacert and providing client cert authentication
+  #
+  # The options password cert cacert and key all refer to file paths
+  # from which spectator will load each of their contents
+  client:
+    ssl:
+      enabled: False
+      cacert:
+      cert:
+      key:
+      password:
+
 
 monitor:
   # The frequency to poll each of the metric sources in the <registry>

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/prometheus_service.py
@@ -188,6 +188,7 @@ class PrometheusMetricsService(object):
 
     self.__catalog = spectator_client.get_source_catalog(options)
     self.__spectator = spectator_client.SpectatorClient(options)
+    self.__params = dict(options)
     options_copy = dict(options)
 
     # prometheus tags must be strings.
@@ -291,7 +292,7 @@ class PrometheusMetricsService(object):
     now = time.time()
     if now - self.__last_collect_time > 1:
       self.__last_collect_metric_map = (
-          self.__spectator.scan_by_service(self.__catalog))
+          self.__spectator.scan_by_service(self.__catalog, params=self.__params))
       self.__last_collect_time = now
 
     all_members = self.collect_with_metrics(self.__last_collect_metric_map)

--- a/spinnaker-monitoring-daemon/spinnaker-monitoring/server_handlers.py
+++ b/spinnaker-monitoring-daemon/spinnaker-monitoring/server_handlers.py
@@ -196,7 +196,7 @@ class MonitorCommandHandler(WebserverCommandHandler):
 
       start = time.time()
       done = start
-      service_metric_map = spectator.scan_by_service(catalog)
+      service_metric_map = spectator.scan_by_service(catalog, params=options)
       collected = time.time()
 
       for service in publishing_services:


### PR DESCRIPTION
 fix(mtls): Add ssl context config when collecting metrics

After configuring mtls / client cert auth, spinnaker-monitoring-daemon becomes unable to collect metrics from `/spectator/metrics`

This allows spinnaker-monitoring-daemon to be configured to optionally use ca verification and client cert auth when collecting metrics.