### PR TITLE
fix(third_party/prometheus_operator): proper indentation in spinnaker-service-monitor.yaml

### DIFF
--- a/spinnaker-monitoring-third-party/third_party/prometheus_operator/spinnaker-service-monitor.yaml
+++ b/spinnaker-monitoring-third-party/third_party/prometheus_operator/spinnaker-service-monitor.yaml
@@ -12,8 +12,8 @@ spec:
   selector:
     matchLabels:
       app: spin
-    namespaceSelector:
-      any: true
+  namespaceSelector:
+    any: true
   endpoints:
   # "port" is string only. "targetPort" is integer or string.
   - targetPort: 8008


### PR DESCRIPTION
Indent spec.namespaceSelector in spinnaker-service-monitor.yaml properly to make it work