### PR TITLE
refactor(config): remove unused spinnaker-monitoring-third-party halconfig 

### DIFF
--- a/spinnaker-monitoring-daemon/halconfig/README.md
+++ b/spinnaker-monitoring-daemon/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton spinnaker-monitoring configs to which Halyard
+concatenates its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated.
+To set a default config value, set a default in the code reading the config
+property.

--- a/spinnaker-monitoring-third-party/halconfig/spinnaker-monitoring-third-party.yml
+++ b/spinnaker-monitoring-third-party/halconfig/spinnaker-monitoring-third-party.yml
@@ -1,1 +1,0 @@
-# halconfig 


### PR DESCRIPTION
* refactor(config): remove unused spinnaker-monitoring-third-party halconfig 

  The spinnaker-monitoring-third-party package does not actually have any Halyard-generated config, and in fact I can't find any references to spinnaker-monitoring-third-party.yml anywhere in this repository. Based on documentation, spinnaker-monitoring-third-party needs to be installed as a debian package, and then users are expected to run one or more of the dashboard installation scripts contained in the package to install third-party dashboards.

* feat(config): deprecate spinnaker-monitoring-daemon halconfig 

  Originally, I had assumed that /spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml contained defaults that were merged with Halyard-mounted spinnaker-monitoring.yml and spinnaker-monitoring-local.yml. However, when spinnaker-monitoring is run as a container, it appears that these defaults are actually ignored and only spinnaker-monitoring.yml and spinnaker-monitoring-local.yml, which are mounted to /opt/spinnaker/monitoring, are merged. This is what I now (think I) understand about config merging in spinnaker-monitoring:

  * In __main__.py, we call [util.merge_options_and_yaml_from_dirs](https://github.com/spinnaker/spinnaker-monitoring/blob/master/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py#L154) to create one merged settings objects.
  * We [search](https://github.com/spinnaker/spinnaker-monitoring/blob/master/spinnaker-monitoring-daemon/spinnaker-monitoring/util.py#L55) for any file named spinnaker-monitoring.yml in any supplied search path, and then search for any file named spinnaker-monitoring-local.yml in any supplied search path, and update the settings object to include any top-level fields not already defined. This does not appear to be a deep merge.
  * The [search paths](https://github.com/spinnaker/spinnaker-monitoring/blob/master/spinnaker-monitoring-daemon/spinnaker-monitoring/__main__.py#L184) are /opt/spinnaker-monitoring/config, /spinnaker-monitoring-daemon, .hal/default/profiles, and .spinnaker/. Since the directories are not recursively searched for matching files, I believe this would exclude /spinnaker-monitoring-daemon/config/spinnaker-monitoring.yml.
