### PR TITLE
chore(java11): use Java 11 to run Gradle

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,7 @@
-FROM openjdk:8
+FROM alpine:3.11
+RUN apk add --update \
+    openjdk11 \
+    && rm -rf /var/cache/apk
 LABEL maintainer="sig-platform@spinnaker.io"
 # The save_cache step will fail if these directories don't exist. We don't have
 # any compilation to do, so just do this instead of running gradle to save time.


### PR DESCRIPTION
The Spinnaker gradle plugin is compiled against Java 11, so we can't use Java 8 anymore. This uses the same OS to compile as the other Spinnaker projects.