### PR TITLE
chore(ci): make a publishDebToArtifactRegistry task at the top level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,9 @@ plugins {
   id "io.spinnaker.artifactregistry-publish" version "$spinnakerGradleVersion"
 }
 
-subprojects {
+allprojects {
   apply plugin: 'nebula.ospackage'
   group = "com.netflix.spinnaker.monitoring"
-
-  tasks.register("publish")
 }
 
 String toVers(String v) {


### PR DESCRIPTION
to avoid
```
Run ./gradlew --info publishDebToArtifactRegistry

* What went wrong:
Task 'publishDebToArtifactRegistry' not found in root project 'spinnaker-monitoring'.
```
from https://github.com/spinnaker/spinnaker-monitoring/runs/6071300143?check_suite_focus=true
