### PR TITLE
chore(ci): Upload halconfigs to GCS on Tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,22 @@ jobs:
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publishDebToArtifactRegistry
+      - name: Login to Google Cloud
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/auth@v0'
+        # use service account flow defined at: https://github.com/google-github-actions/upload-cloud-storage#authenticating-via-service-account-key-json
+        with:
+          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+      - name: Upload halconfig profiles to GCS
+        # https://console.cloud.google.com/storage/browser/halconfig
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/upload-cloud-storage@v0'
+        with:
+          path: 'spinnaker-monitoring-daemon/halconfig/'
+          destination: 'halconfig/${{ steps.build_variables.outputs.REPO }}/${{ steps.release_info.outputs.RELEASE_VERSION }}'
+          parent: false
       - name: Login to GAR
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=build
+
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
@@ -6,9 +11,9 @@ pull_request_rules:
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge release branch changes on CI success and release manager review
@@ -18,9 +23,9 @@ pull_request_rules:
       - "label=ready to merge"
       - "approved-reviews-by=@release-managers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   # This rule exists to handle release branches that are still building using Travis CI instead of
@@ -32,8 +37,41 @@ pull_request_rules:
       - "label=ready to merge"
       - "approved-reviews-by=@release-managers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
+  - name: Automatically merge PRs from maintainers on CI success and review
+    conditions:
+      - base=master
+      - status-success=build
+      - "label=ready to merge"
+      - "author=@oss-approvers"
+    actions:
+      queue:
+        method: squash
+        name: default
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge autobump PRs on CI success
+    conditions:
+      - base=master
+      - status-success=build
+      - "label~=autobump-*"
+      - "author:spinnakerbot"
+    actions:
+      queue:
+        method: squash
+        name: default
+      label:
+        add: ["auto merged"]
+  - name: Request reviews for autobump PRs on CI failure
+    conditions:
+      - base=master
+      - status-failure=build
+      - "label~=autobump-*"
+      - base=master
+    actions:
+      request_reviews:
+        teams: ["oss-approvers"]


### PR DESCRIPTION
Previous release tools would publish basic halconfig profiles to GCS
bucket: [https://console.cloud.google.com/storage/browser/halconfig/`<service>`/`<version>`/*](https://console.cloud.google.com/storage/browser/halconfig/%60%3Cservice%3E%60/%60%3Cversion%3E%60/*)

Where `<service>` might be `rosco` and `<version>` is our git tag, eg: `v1.2.3`.

Halyard downloads these profiles during `hal deploy apply`.
As the profiles are deprecated it would be ideal to remove from Halyard
but it may break users workflows.

For now we can upload the files as part of our regular service 'release'
flow (git tag <version> && git push) using GHA.